### PR TITLE
feat(cleanup): add smart cleanup recommendations with value scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ CLAUDE.md
 # Specs
 specs/
 
+docs/
+community/
 AGENTS.md

--- a/README.md
+++ b/README.md
@@ -207,6 +207,28 @@ Need the same snapshot for tooling or an AI agent?
 cc9s status --json
 ```
 
+### Smart Cleanup
+
+`cc9s sessions cleanup --dry-run` now scores session value and groups cleanup suggestions into actionable recommendation tiers:
+
+```text
+cc9s sessions cleanup --dry-run
+
+Session Cleanup Preview (dry-run — no data was modified)
+
+  Filters:  state=stale
+
+Summary
+  Matched:  16 sessions across 5 projects (4.2 MB)
+
+Recommendations
+  Delete:   12 sessions (safe to remove)
+  Review:   3 sessions (check before deleting)
+  Keep:     1 sessions (valuable content)
+```
+
+Each session is assessed from conversation depth, tool usage, token investment, and content volume. Use `--json` for full recommendation, score, and reason details.
+
 ### Full Help
 
 The CLI surface is best viewed directly from the binary:
@@ -223,7 +245,7 @@ Usage:
   cc9s projects inspect <name>  Project details (match by name or path)
   cc9s sessions list        List sessions across all projects
   cc9s sessions inspect <id>   Session details (exact ID from list output)
-  cc9s sessions cleanup --dry-run  Preview stale/old sessions (read-only)
+  cc9s sessions cleanup --dry-run  Preview smart cleanup recommendations (read-only)
   cc9s skills list          List skills and commands
   cc9s agents list          List agents
   cc9s agents inspect <name>   Agent details (match by name or path)
@@ -274,7 +296,7 @@ Common patterns:
   cc9s status --json                        Machine-readable overview
   cc9s sessions list --state active --json  Find active sessions, get full IDs
   cc9s sessions inspect <id> --json         Full session details (model, tokens, lifecycle)
-  cc9s sessions cleanup --dry-run           Preview what would be cleaned up
+  cc9s sessions cleanup --dry-run           Preview smart cleanup recommendations
   cc9s projects inspect cc9s               Inspect a specific project
   cc9s skills list --project cc9s --json    Skills for one project
 ```
@@ -320,6 +342,7 @@ Type `:` to enter command mode. Press `Tab` to autocomplete.
 | `:projects` | Show projects |
 | `:context all` | Switch current resource to all-project context |
 | `:context <name>` | Filter current resource by project context |
+| `:cleanup` | Toggle the RECOMMEND cleanup column in sessions view |
 | `:q` | Quit |
 
 ## How It Works

--- a/README_zh.md
+++ b/README_zh.md
@@ -207,6 +207,28 @@ Top Projects
 cc9s status --json
 ```
 
+### 智能清理建议
+
+`cc9s sessions cleanup --dry-run` 现在会对会话内容价值打分，并按 recommendation 分层展示清理建议：
+
+```text
+cc9s sessions cleanup --dry-run
+
+Session Cleanup Preview (dry-run — no data was modified)
+
+  Filters:  state=stale
+
+Summary
+  Matched:  16 sessions across 5 projects (4.2 MB)
+
+Recommendations
+  Delete:   12 sessions (safe to remove)
+  Review:   3 sessions (check before deleting)
+  Keep:     1 sessions (valuable content)
+```
+
+每个会话都会基于对话深度、工具使用、token 投入和内容体量做评估。使用 `--json` 可以拿到完整的 recommendation、score 和 reasons 字段。
+
 ### 完整帮助
 
 CLI 的完整命令面，直接以二进制帮助输出为准：
@@ -223,7 +245,7 @@ Usage:
   cc9s projects inspect <name>  Project details (match by name or path)
   cc9s sessions list        List sessions across all projects
   cc9s sessions inspect <id>   Session details (exact ID from list output)
-  cc9s sessions cleanup --dry-run  Preview stale/old sessions (read-only)
+  cc9s sessions cleanup --dry-run  Preview smart cleanup recommendations (read-only)
   cc9s skills list          List skills and commands
   cc9s agents list          List agents
   cc9s agents inspect <name>   Agent details (match by name or path)
@@ -274,7 +296,7 @@ Common patterns:
   cc9s status --json                        Machine-readable overview
   cc9s sessions list --state active --json  Find active sessions, get full IDs
   cc9s sessions inspect <id> --json         Full session details (model, tokens, lifecycle)
-  cc9s sessions cleanup --dry-run           Preview what would be cleaned up
+  cc9s sessions cleanup --dry-run           Preview smart cleanup recommendations
   cc9s projects inspect cc9s               Inspect a specific project
   cc9s skills list --project cc9s --json    Skills for one project
 ```
@@ -320,6 +342,7 @@ Common patterns:
 | `:projects` | 显示项目列表 |
 | `:context all` | 将当前资源切换到全部项目上下文 |
 | `:context <名称>` | 按项目上下文过滤当前资源 |
+| `:cleanup` | 在 sessions 视图中切换 RECOMMEND 清理建议列 |
 | `:q` | 退出 |
 
 ## 工作原理

--- a/internal/claudefs/types.go
+++ b/internal/claudefs/types.go
@@ -94,3 +94,19 @@ type SessionHealth struct {
 	IsReliable bool
 	Problem    string
 }
+
+// CleanupRecommendation indicates how strongly a session should be cleaned up.
+type CleanupRecommendation string
+
+const (
+	RecommendDelete CleanupRecommendation = "Delete"
+	RecommendMaybe  CleanupRecommendation = "Maybe"
+	RecommendKeep   CleanupRecommendation = "Keep"
+)
+
+// SessionAssessment is the value assessment result for a session.
+type SessionAssessment struct {
+	Score          int
+	Recommendation CleanupRecommendation
+	Reasons        []string
+}

--- a/internal/claudefs/value.go
+++ b/internal/claudefs/value.go
@@ -1,0 +1,110 @@
+package claudefs
+
+import "fmt"
+
+// AssessSessionValue scores a session's content value and returns a cleanup recommendation.
+// Higher scores indicate more valuable sessions that should be kept.
+func AssessSessionValue(stats SessionStats, lifecycle SessionLifecycleSnapshot, fileSize int64) SessionAssessment {
+	if lifecycle.State == SessionLifecycleActive || lifecycle.State == SessionLifecycleIdle {
+		return SessionAssessment{
+			Score:          100,
+			Recommendation: RecommendKeep,
+			Reasons:        []string{fmt.Sprintf("session is %s", lifecycle.State)},
+		}
+	}
+
+	if lifecycle.State == SessionLifecycleStale {
+		reasons := []string{"session data is unreliable (Stale)"}
+		reasons = append(reasons, lifecycle.Evidence.Reasons...)
+		return SessionAssessment{
+			Score:          0,
+			Recommendation: RecommendDelete,
+			Reasons:        reasons,
+		}
+	}
+
+	score := 0
+	var reasons []string
+
+	switch {
+	case stats.TurnCount >= 20:
+		score += 30
+	case stats.TurnCount >= 10:
+		score += 20
+	case stats.TurnCount >= 5:
+		score += 12
+	case stats.TurnCount >= 3:
+		score += 5
+	default:
+		reasons = append(reasons, fmt.Sprintf("shallow conversation (%d turns)", stats.TurnCount))
+	}
+
+	switch {
+	case stats.ToolCallCount >= 30:
+		score += 30
+	case stats.ToolCallCount >= 15:
+		score += 22
+	case stats.ToolCallCount >= 5:
+		score += 12
+	case stats.ToolCallCount >= 1:
+		score += 5
+	default:
+		reasons = append(reasons, "no tool calls")
+	}
+
+	totalTokens := stats.InputTokens + stats.OutputTokens
+	switch {
+	case totalTokens >= 50000:
+		score += 25
+	case totalTokens >= 20000:
+		score += 18
+	case totalTokens >= 5000:
+		score += 10
+	case totalTokens >= 1000:
+		score += 4
+	default:
+		reasons = append(reasons, "minimal token usage")
+	}
+
+	switch {
+	case fileSize >= 100000:
+		score += 15
+	case fileSize >= 50000:
+		score += 10
+	case fileSize >= 10000:
+		score += 5
+	}
+
+	if score > 100 {
+		score = 100
+	}
+
+	recommendation := scoreToRecommendation(score)
+	switch recommendation {
+	case RecommendKeep:
+		reasons = append(reasons, fmt.Sprintf("substantial session (%d turns, %d tool calls)", stats.TurnCount, stats.ToolCallCount))
+	case RecommendMaybe:
+		reasons = append(reasons, "moderate content value - review before deleting")
+	}
+
+	if len(reasons) == 0 {
+		reasons = []string{"standard content value"}
+	}
+
+	return SessionAssessment{
+		Score:          score,
+		Recommendation: recommendation,
+		Reasons:        reasons,
+	}
+}
+
+func scoreToRecommendation(score int) CleanupRecommendation {
+	switch {
+	case score >= 60:
+		return RecommendKeep
+	case score >= 30:
+		return RecommendMaybe
+	default:
+		return RecommendDelete
+	}
+}

--- a/internal/claudefs/value_quick.go
+++ b/internal/claudefs/value_quick.go
@@ -1,0 +1,92 @@
+package claudefs
+
+import "fmt"
+
+// QuickAssessSession provides a lightweight value assessment using only Session fields.
+func QuickAssessSession(s Session) SessionAssessment {
+	if s.Lifecycle.State == SessionLifecycleActive || s.Lifecycle.State == SessionLifecycleIdle {
+		return SessionAssessment{
+			Score:          100,
+			Recommendation: RecommendKeep,
+			Reasons:        []string{fmt.Sprintf("session is %s", s.Lifecycle.State)},
+		}
+	}
+
+	if s.Lifecycle.State == SessionLifecycleStale {
+		reasons := []string{"session data is unreliable (Stale)"}
+		reasons = append(reasons, s.Lifecycle.Evidence.Reasons...)
+		return SessionAssessment{
+			Score:          0,
+			Recommendation: RecommendDelete,
+			Reasons:        reasons,
+		}
+	}
+
+	score := 0
+	var reasons []string
+
+	switch {
+	case s.EventCount >= 200:
+		score += 35
+	case s.EventCount >= 50:
+		score += 25
+	case s.EventCount >= 20:
+		score += 15
+	case s.EventCount >= 8:
+		score += 8
+	default:
+		reasons = append(reasons, fmt.Sprintf("few events (%d)", s.EventCount))
+	}
+
+	switch {
+	case s.FileSize >= 100000:
+		score += 35
+	case s.FileSize >= 30000:
+		score += 25
+	case s.FileSize >= 10000:
+		score += 15
+	case s.FileSize >= 3000:
+		score += 5
+	default:
+		reasons = append(reasons, "small session file")
+	}
+
+	switch {
+	case len(s.Summary) >= 60:
+		score += 20
+	case len(s.Summary) >= 30:
+		score += 12
+	case len(s.Summary) >= 10:
+		score += 5
+	default:
+		reasons = append(reasons, "brief or missing summary")
+	}
+
+	if s.Summary == "" || s.Summary == "-" {
+		reasons = append(reasons, "no summary")
+	} else {
+		score += 10
+	}
+
+	if score > 100 {
+		score = 100
+	}
+
+	recommendation := scoreToRecommendation(score)
+	switch recommendation {
+	case RecommendKeep:
+		reasons = append(reasons, fmt.Sprintf("substantial session (%d events, %s)", s.EventCount, FormatSize(s.FileSize)))
+	case RecommendMaybe:
+		reasons = append(reasons, "moderate content - review before deleting")
+	}
+
+	if len(reasons) == 0 {
+		reasons = []string{"standard content value"}
+	}
+
+	return SessionAssessment{
+		Score:          score,
+		Recommendation: recommendation,
+		Reasons:        reasons,
+	}
+}

--- a/internal/claudefs/value_test.go
+++ b/internal/claudefs/value_test.go
@@ -1,0 +1,204 @@
+package claudefs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAssessSessionValue_StaleAlwaysRecommendDelete(t *testing.T) {
+	stats := SessionStats{
+		TurnCount:     1,
+		ToolCallCount: 0,
+		InputTokens:   100,
+		OutputTokens:  50,
+	}
+	lifecycle := SessionLifecycleSnapshot{
+		State: SessionLifecycleStale,
+	}
+
+	a := AssessSessionValue(stats, lifecycle, 100)
+
+	if a.Recommendation != RecommendDelete {
+		t.Errorf("Stale session: want Delete, got %s", a.Recommendation)
+	}
+}
+
+func TestAssessSessionValue_HighValueSession(t *testing.T) {
+	stats := SessionStats{
+		TurnCount:     25,
+		ToolCallCount: 40,
+		InputTokens:   50000,
+		OutputTokens:  30000,
+		Duration:      2 * time.Hour,
+	}
+	lifecycle := SessionLifecycleSnapshot{
+		State: SessionLifecycleCompleted,
+	}
+
+	a := AssessSessionValue(stats, lifecycle, 5000)
+
+	if a.Recommendation != RecommendKeep {
+		t.Errorf("High-value session: want Keep, got %s (score=%d)", a.Recommendation, a.Score)
+	}
+	if a.Score < 60 {
+		t.Errorf("High-value session score too low: %d", a.Score)
+	}
+}
+
+func TestAssessSessionValue_LowValueSession(t *testing.T) {
+	stats := SessionStats{
+		TurnCount:     2,
+		ToolCallCount: 0,
+		InputTokens:   200,
+		OutputTokens:  100,
+		Duration:      30 * time.Second,
+	}
+	lifecycle := SessionLifecycleSnapshot{
+		State: SessionLifecycleCompleted,
+	}
+
+	a := AssessSessionValue(stats, lifecycle, 500)
+
+	if a.Recommendation != RecommendDelete {
+		t.Errorf("Low-value session: want Delete, got %s (score=%d)", a.Recommendation, a.Score)
+	}
+}
+
+func TestAssessSessionValue_MediumValueSession(t *testing.T) {
+	stats := SessionStats{
+		TurnCount:     8,
+		ToolCallCount: 5,
+		InputTokens:   5000,
+		OutputTokens:  3000,
+		Duration:      15 * time.Minute,
+	}
+	lifecycle := SessionLifecycleSnapshot{
+		State: SessionLifecycleCompleted,
+	}
+
+	a := AssessSessionValue(stats, lifecycle, 2000)
+
+	if a.Recommendation != RecommendMaybe {
+		t.Errorf("Medium-value session: want Maybe, got %s (score=%d)", a.Recommendation, a.Score)
+	}
+}
+
+func TestAssessSessionValue_ActiveAlwaysKeep(t *testing.T) {
+	stats := SessionStats{
+		TurnCount:     1,
+		ToolCallCount: 0,
+	}
+	lifecycle := SessionLifecycleSnapshot{
+		State: SessionLifecycleActive,
+	}
+
+	a := AssessSessionValue(stats, lifecycle, 100)
+
+	if a.Recommendation != RecommendKeep {
+		t.Errorf("Active session: want Keep, got %s", a.Recommendation)
+	}
+}
+
+func TestAssessSessionValue_IdleAlwaysKeep(t *testing.T) {
+	stats := SessionStats{
+		TurnCount:     3,
+		ToolCallCount: 1,
+	}
+	lifecycle := SessionLifecycleSnapshot{
+		State: SessionLifecycleIdle,
+	}
+
+	a := AssessSessionValue(stats, lifecycle, 800)
+
+	if a.Recommendation != RecommendKeep {
+		t.Errorf("Idle session: want Keep, got %s", a.Recommendation)
+	}
+}
+
+func TestAssessSessionValue_Reasons(t *testing.T) {
+	stats := SessionStats{
+		TurnCount:     1,
+		ToolCallCount: 0,
+		InputTokens:   100,
+		OutputTokens:  50,
+	}
+	lifecycle := SessionLifecycleSnapshot{
+		State: SessionLifecycleCompleted,
+	}
+
+	a := AssessSessionValue(stats, lifecycle, 300)
+
+	if len(a.Reasons) == 0 {
+		t.Error("Assessment should have at least one reason")
+	}
+}
+
+func TestScoreToRecommendation(t *testing.T) {
+	tests := []struct {
+		score int
+		want  CleanupRecommendation
+	}{
+		{0, RecommendDelete},
+		{29, RecommendDelete},
+		{30, RecommendMaybe},
+		{59, RecommendMaybe},
+		{60, RecommendKeep},
+		{100, RecommendKeep},
+	}
+	for _, tt := range tests {
+		got := scoreToRecommendation(tt.score)
+		if got != tt.want {
+			t.Errorf("scoreToRecommendation(%d): want %s, got %s", tt.score, tt.want, got)
+		}
+	}
+}
+
+func TestQuickAssessSession_StaleSmallFile(t *testing.T) {
+	s := Session{
+		FileSize:   300,
+		EventCount: 5,
+		Lifecycle: SessionLifecycleSnapshot{
+			State: SessionLifecycleStale,
+		},
+	}
+
+	a := QuickAssessSession(s)
+
+	if a.Recommendation != RecommendDelete {
+		t.Errorf("Stale small file: want Delete, got %s", a.Recommendation)
+	}
+}
+
+func TestQuickAssessSession_CompletedLargeFile(t *testing.T) {
+	s := Session{
+		FileSize:   200000,
+		EventCount: 500,
+		Summary:    "implement the full authentication system with JWT tokens",
+		Lifecycle: SessionLifecycleSnapshot{
+			State: SessionLifecycleCompleted,
+		},
+	}
+
+	a := QuickAssessSession(s)
+
+	if a.Recommendation != RecommendKeep {
+		t.Errorf("Large completed session: want Keep, got %s (score=%d)", a.Recommendation, a.Score)
+	}
+}
+
+func TestQuickAssessSession_CompletedTinySession(t *testing.T) {
+	s := Session{
+		FileSize:   800,
+		EventCount: 3,
+		Summary:    "hi",
+		Lifecycle: SessionLifecycleSnapshot{
+			State: SessionLifecycleCompleted,
+		},
+	}
+
+	a := QuickAssessSession(s)
+
+	if a.Recommendation != RecommendDelete {
+		t.Errorf("Tiny completed session: want Delete, got %s (score=%d)", a.Recommendation, a.Score)
+	}
+}

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -348,6 +348,9 @@ type CleanupSummary struct {
 	MatchedSessions int   `json:"matched_sessions"`
 	MatchedProjects int   `json:"matched_projects"`
 	TotalSizeBytes  int64 `json:"total_size_bytes"`
+	DeleteCount     int   `json:"delete_count"`
+	MaybeCount      int   `json:"maybe_count"`
+	KeepCount       int   `json:"keep_count"`
 }
 
 // CleanupProjectGroup is one project group in the cleanup preview.
@@ -358,9 +361,12 @@ type CleanupProjectGroup struct {
 
 // CleanupSessionMatch is one matched session in a cleanup preview.
 type CleanupSessionMatch struct {
-	ID        string  `json:"id"`
-	Project   string  `json:"project"`
-	State     string  `json:"state"`
-	AgeHours  float64 `json:"age_hours"`
-	UpdatedAt string  `json:"updated_at"`
+	ID             string   `json:"id"`
+	Project        string   `json:"project"`
+	State          string   `json:"state"`
+	AgeHours       float64  `json:"age_hours"`
+	UpdatedAt      string   `json:"updated_at"`
+	Recommendation string   `json:"recommendation"`
+	Score          int      `json:"score"`
+	Reasons        []string `json:"reasons"`
 }

--- a/internal/cli/contracts_test.go
+++ b/internal/cli/contracts_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -104,4 +105,111 @@ func TestRenderSkillAndAgentListTextIncludePaths(t *testing.T) {
 			t.Fatalf("agent list output missing path field:\n%s", out)
 		}
 	})
+}
+
+func TestCleanupResultJSONIncludesAssessmentFields(t *testing.T) {
+	data, err := json.Marshal(CleanupResult{
+		DryRun: true,
+		Summary: CleanupSummary{
+			MatchedSessions: 3,
+			MatchedProjects: 1,
+			TotalSizeBytes:  4096,
+			DeleteCount:     1,
+			MaybeCount:      1,
+			KeepCount:       1,
+		},
+		Sessions: []CleanupSessionMatch{{
+			ID:             "session-1",
+			Project:        "cc9s",
+			State:          "Completed",
+			AgeHours:       72,
+			UpdatedAt:      "2026-03-25T10:00:00Z",
+			Recommendation: "Delete",
+			Score:          5,
+			Reasons:        []string{"small session file"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal cleanup result: %v", err)
+	}
+
+	out := string(data)
+	for _, want := range []string{
+		`"delete_count":1`,
+		`"maybe_count":1`,
+		`"keep_count":1`,
+		`"recommendation":"Delete"`,
+		`"score":5`,
+		`"reasons":["small session file"]`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cleanup json missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderCleanupTextShowsRecommendationGroups(t *testing.T) {
+	var buf bytes.Buffer
+	renderCleanupText(&buf, CleanupResult{
+		DryRun: true,
+		Filters: CleanupFilters{
+			State:     "stale",
+			OlderThan: "72h",
+			Project:   "cc9s",
+		},
+		Summary: CleanupSummary{
+			MatchedSessions: 3,
+			MatchedProjects: 1,
+			TotalSizeBytes:  4096,
+			DeleteCount:     1,
+			MaybeCount:      1,
+			KeepCount:       1,
+		},
+		Projects: []CleanupProjectGroup{{
+			Name:         "cc9s",
+			SessionCount: 3,
+		}},
+		Sessions: []CleanupSessionMatch{
+			{
+				ID:             "session-delete",
+				Project:        "cc9s",
+				State:          "Completed",
+				Recommendation: "Delete",
+				Reasons:        []string{"small session file"},
+			},
+			{
+				ID:             "session-maybe",
+				Project:        "cc9s",
+				State:          "Completed",
+				Recommendation: "Maybe",
+				Reasons:        []string{"moderate content"},
+			},
+			{
+				ID:             "session-keep",
+				Project:        "cc9s",
+				State:          "Idle",
+				Recommendation: "Keep",
+				Reasons:        []string{"session is Idle"},
+			},
+		},
+	})
+
+	out := buf.String()
+	for _, want := range []string{
+		"Recommendations",
+		"Delete:   1 sessions",
+		"Review:   1 sessions",
+		"Keep:     1 sessions",
+		"Tip",
+		"usually only shows Delete",
+		"\"--state completed\"",
+		"Recommended for deletion (1)",
+		"Review before deleting (1)",
+		"Recommended to keep (1)",
+		"small session file",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cleanup text missing %q:\n%s", want, out)
+		}
+	}
 }

--- a/internal/cli/execute.go
+++ b/internal/cli/execute.go
@@ -494,13 +494,17 @@ func executeSessionsCleanup(cmd *Command) (CommandResult, error) {
 				}
 			}
 
+			assessment := claudefs.QuickAssessSession(s)
 			ageHours := now.Sub(s.LastActiveAt).Hours()
 			matches = append(matches, CleanupSessionMatch{
-				ID:        s.ID,
-				Project:   project.Name,
-				State:     string(s.Lifecycle.State),
-				AgeHours:  ageHours,
-				UpdatedAt: formatTimeRFC3339(s.LastActiveAt),
+				ID:             s.ID,
+				Project:        project.Name,
+				State:          string(s.Lifecycle.State),
+				AgeHours:       ageHours,
+				UpdatedAt:      formatTimeRFC3339(s.LastActiveAt),
+				Recommendation: string(assessment.Recommendation),
+				Score:          assessment.Score,
+				Reasons:        assessment.Reasons,
 			})
 			totalSize += s.FileSize
 			projectMatchCount++
@@ -520,6 +524,18 @@ func executeSessionsCleanup(cmd *Command) (CommandResult, error) {
 		})
 	}
 
+	var deleteCount, maybeCount, keepCount int
+	for _, match := range matches {
+		switch claudefs.CleanupRecommendation(match.Recommendation) {
+		case claudefs.RecommendDelete:
+			deleteCount++
+		case claudefs.RecommendMaybe:
+			maybeCount++
+		case claudefs.RecommendKeep:
+			keepCount++
+		}
+	}
+
 	return CleanupResult{
 		DryRun: true,
 		Filters: CleanupFilters{
@@ -531,6 +547,9 @@ func executeSessionsCleanup(cmd *Command) (CommandResult, error) {
 			MatchedSessions: len(matches),
 			MatchedProjects: len(projects),
 			TotalSizeBytes:  totalSize,
+			DeleteCount:     deleteCount,
+			MaybeCount:      maybeCount,
+			KeepCount:       keepCount,
 		},
 		Projects: projects,
 		Sessions: matches,

--- a/internal/cli/render_text.go
+++ b/internal/cli/render_text.go
@@ -288,43 +288,89 @@ func renderCleanupText(w io.Writer, r CleanupResult) {
 	fmt.Fprintln(w, "Session Cleanup Preview (dry-run — no data was modified)")
 	fmt.Fprintln(w)
 
-	fmt.Fprintf(w, "Filters: state=%s", r.Filters.State)
-	if r.Filters.Project != "" {
-		fmt.Fprintf(w, ", project=%s", r.Filters.Project)
-	}
+	fmt.Fprintf(w, "  Filters:  state=%s", r.Filters.State)
 	if r.Filters.OlderThan != "" {
-		fmt.Fprintf(w, ", older_than=%s", r.Filters.OlderThan)
+		fmt.Fprintf(w, "  older-than=%s", r.Filters.OlderThan)
+	}
+	if r.Filters.Project != "" {
+		fmt.Fprintf(w, "  project=%s", r.Filters.Project)
 	}
 	fmt.Fprintln(w)
 
-	fmt.Fprintf(w, "\nSummary\n")
-	fmt.Fprintf(w, "  Matched Sessions: %d\n", r.Summary.MatchedSessions)
-	fmt.Fprintf(w, "  Matched Projects: %d\n", r.Summary.MatchedProjects)
-	fmt.Fprintf(w, "  Total Size:       %s\n", formatSize(r.Summary.TotalSizeBytes))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Summary")
+	fmt.Fprintf(w, "  Matched:  %d sessions across %d projects (%s)\n",
+		r.Summary.MatchedSessions, r.Summary.MatchedProjects, formatSize(r.Summary.TotalSizeBytes))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Recommendations")
+	if r.Summary.DeleteCount > 0 {
+		fmt.Fprintf(w, "  Delete:   %d sessions (safe to remove)\n", r.Summary.DeleteCount)
+	}
+	if r.Summary.MaybeCount > 0 {
+		fmt.Fprintf(w, "  Review:   %d sessions (check before deleting)\n", r.Summary.MaybeCount)
+	}
+	if r.Summary.KeepCount > 0 {
+		fmt.Fprintf(w, "  Keep:     %d sessions (valuable content)\n", r.Summary.KeepCount)
+	}
+	if strings.EqualFold(r.Filters.State, "stale") {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Tip")
+		fmt.Fprintln(w, "  Default cleanup targets stale sessions, so this view usually only shows Delete.")
+		fmt.Fprintln(w, "  Use \"--state completed\" to see Delete / Review / Keep recommendations.")
+	}
 
 	if len(r.Projects) > 0 {
-		fmt.Fprintf(w, "\nProjects\n")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Projects")
 		for _, p := range r.Projects {
-			fmt.Fprintf(w, "  %s  %d sessions\n", p.Name, p.SessionCount)
+			fmt.Fprintf(w, "  %-30s %d sessions\n", p.Name, p.SessionCount)
 		}
 	}
 
-	// In text mode, show up to 10 sessions as a preview
-	fmt.Fprintf(w, "\nSessions (preview)\n")
-	limit := len(r.Sessions)
+	fmt.Fprintln(w)
+	printSessionGroup(w, r.Sessions, "Delete", "Recommended for deletion")
+	printSessionGroup(w, r.Sessions, "Maybe", "Review before deleting")
+	printSessionGroup(w, r.Sessions, "Keep", "Recommended to keep")
+
+	if len(r.Sessions) > 30 {
+		fmt.Fprintf(w, "  ... showing top 30 of %d sessions (use --json for full list)\n", len(r.Sessions))
+	}
+}
+
+func printSessionGroup(w io.Writer, sessions []CleanupSessionMatch, recommendation string, header string) {
+	var group []CleanupSessionMatch
+	for _, s := range sessions {
+		if s.Recommendation == recommendation {
+			group = append(group, s)
+		}
+	}
+	if len(group) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "%s (%d)\n", header, len(group))
+	limit := len(group)
 	if limit > 10 {
 		limit = 10
 	}
-	for i := 0; i < limit; i++ {
-		s := r.Sessions[i]
-		fmt.Fprintf(w, "  %s  %s  %s  %s\n", truncateText(s.ID, 16), s.Project, s.State, s.UpdatedAt)
+	for _, s := range group[:limit] {
+		reason := ""
+		if len(s.Reasons) > 0 {
+			reason = s.Reasons[0]
+		}
+		fmt.Fprintf(w, "  %-12s %-20s %-10s  %s\n", s.ID[:minInt(12, len(s.ID))], s.Project, s.State, reason)
 	}
-	if len(r.Sessions) > 10 {
-		fmt.Fprintf(w, "  ... and %d more sessions (use --json for full list)\n", len(r.Sessions)-10)
+	if len(group) > 10 {
+		fmt.Fprintf(w, "  ... and %d more\n", len(group)-10)
 	}
-
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Preview only — no data was modified.")
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // --- Formatting helpers ---

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -295,6 +295,12 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, setContext(a, msg.Context)
 		}
 
+	case ToggleCleanupHintsMsg:
+		if a.sessionList != nil {
+			a.sessionList.showCleanupHints = !a.sessionList.showCleanupHints
+		}
+		return a, nil
+
 	case DeleteSessionsMsg:
 		// Execute deletion asynchronously
 		return a, deleteSessionsCmd(msg.Targets)
@@ -910,6 +916,9 @@ func (a *AppModel) commandCompletionCandidates(input string, excludeExact bool) 
 	if len(segments) == 1 {
 		prefix := segments[0]
 		commands := append(a.resourceRegistry.CompletionCandidates(prefix), "context")
+		if a.currentResource == ResourceSessions {
+			commands = append(commands, "cleanup")
+		}
 		candidates := make([]string, 0, len(commands))
 		for _, cmd := range commands {
 			if !strings.HasPrefix(cmd, prefix) {
@@ -1006,6 +1015,11 @@ func (a *AppModel) executeCommand(cmdStr string) tea.Cmd {
 		return func() tea.Msg {
 			return SwitchContextMsg{Context: Context{Type: ContextProject, Value: parts[1]}}
 		}
+	case "cleanup":
+		if a.currentResource == ResourceSessions {
+			return func() tea.Msg { return ToggleCleanupHintsMsg{} }
+		}
+		return nil
 	default:
 		if descriptor, ok := a.resourceRegistry.FindByCommand(parts[0]); ok {
 			return func() tea.Msg { return SwitchResourceMsg{Resource: descriptor.Resource} }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -382,6 +382,58 @@ func TestCurrentHeaderStateUsesDescriptorForSkillProjectContext(t *testing.T) {
 	}
 }
 
+func TestCleanupCommandTogglesSessionCleanupHints(t *testing.T) {
+	app := NewAppModel()
+	app.setActiveResource(ResourceSessions)
+	app.sessionList = NewSessionListModel()
+	app.sessionList.loading = false
+
+	cmd := app.executeCommand("cleanup")
+	if cmd == nil {
+		t.Fatal("expected cleanup command to emit a toggle message")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(ToggleCleanupHintsMsg); !ok {
+		t.Fatalf("expected ToggleCleanupHintsMsg, got %T", msg)
+	}
+
+	model, nextCmd := app.Update(msg)
+	if nextCmd != nil {
+		t.Fatalf("expected no follow-up command when toggling cleanup hints, got %v", nextCmd)
+	}
+
+	appModel := model.(*AppModel)
+	if !appModel.sessionList.showCleanupHints {
+		t.Fatal("expected cleanup hints to be enabled")
+	}
+}
+
+func TestCleanupCommandCompletionOnlyInSessions(t *testing.T) {
+	app := NewAppModel()
+	app.setActiveResource(ResourceSessions)
+
+	candidates, _, _ := app.commandCompletionCandidates("cl", false)
+	found := false
+	for _, candidate := range candidates {
+		if candidate == "cleanup" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected cleanup completion in sessions, got %#v", candidates)
+	}
+
+	app.setActiveResource(ResourceProjects)
+	candidates, _, _ = app.commandCompletionCandidates("cl", false)
+	for _, candidate := range candidates {
+		if candidate == "cleanup" {
+			t.Fatalf("cleanup should not complete outside sessions, got %#v", candidates)
+		}
+	}
+}
+
 func TestCurrentHeaderStateUsesDescriptorForAgentLoadError(t *testing.T) {
 	app := NewAppModel()
 	app.setActiveResource(ResourceAgents)

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -54,6 +54,13 @@ func renderHelp(width, height int, registry *ResourceRegistry, active ResourceDe
 	}
 	lines = append(lines,
 		"  "+styles.FooterKeyStyle.Render(":context")+styles.FooterStyle.Render("   Switch context (all / project name)"),
+	)
+	if active.Resource == ResourceSessions {
+		lines = append(lines,
+			"  "+styles.FooterKeyStyle.Render(":cleanup")+styles.FooterStyle.Render("   Toggle cleanup recommendations"),
+		)
+	}
+	lines = append(lines,
 		"  "+styles.FooterKeyStyle.Render("Tab")+styles.FooterStyle.Render("       Auto-complete commands"),
 		"",
 		"  "+styles.HeaderStyle.Render("Dialog"),

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -23,4 +23,12 @@ func TestRenderHelpUsesRegistryCommandNamesAndActiveCapabilities(t *testing.T) {
 	if strings.Contains(output, "Switch to all projects") {
 		t.Fatal("expected projects help to omit active all-context shortcut guidance")
 	}
+
+	output = renderHelp(120, 40, registry, registry.MustGet(ResourceSessions))
+	if !strings.Contains(output, ":cleanup") {
+		t.Fatal("expected sessions help to include cleanup command guidance")
+	}
+	if !strings.Contains(output, "Toggle cleanup recommendations") {
+		t.Fatal("expected sessions help to describe cleanup recommendations")
+	}
 }

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -140,3 +140,6 @@ type SessionsDeletedMsg struct {
 	Deleted int
 	Errs    []error
 }
+
+// ToggleCleanupHintsMsg toggles the cleanup recommendation column in session view.
+type ToggleCleanupHintsMsg struct{}

--- a/internal/ui/session_list.go
+++ b/internal/ui/session_list.go
@@ -37,6 +37,7 @@ type SessionListModel struct {
 	sortAsc          bool
 	restoreSessionID string
 	restoreCursor    int
+	showCleanupHints bool
 }
 
 // sessionsLoadedMsg session data loaded message
@@ -83,6 +84,11 @@ func (m *SessionListModel) SetContext(ctx Context) tea.Cmd {
 // ShowProjectColumn whether to show the PROJECT column
 func (m *SessionListModel) ShowProjectColumn() bool {
 	return m.context.Type == ContextAll
+}
+
+// SetCleanupHints enables or disables the cleanup recommendation column.
+func (m *SessionListModel) SetCleanupHints(show bool) {
+	m.showCleanupHints = show
 }
 
 func (m *SessionListModel) Init() tea.Cmd {
@@ -228,7 +234,12 @@ func (m *SessionListModel) View(width, height int) string {
 		contextLabel = m.context.Value
 	}
 
-	return renderSessionTable(m.sessions, m.cursor, width, height, m.selectedRows, m.ShowProjectColumn(), m.sortBy, m.sortAsc, contextLabel)
+	return renderSessionTable(
+		m.sessions, m.cursor, width, height,
+		m.selectedRows, m.ShowProjectColumn(),
+		m.sortBy, m.sortAsc, contextLabel,
+		m.showCleanupHints,
+	)
 }
 
 // Reload reloads all session data
@@ -326,6 +337,20 @@ func queryLooksLikeLifecycleState(query string) bool {
 	return false
 }
 
+func queryLooksLikeRecommendation(query string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	for _, prefix := range []string{"delete", "maybe", "keep", "del", "rem"} {
+		if strings.HasPrefix(prefix, query) {
+			return true
+		}
+	}
+	return false
+}
+
+func recommendationMatchesQuery(rec claudefs.CleanupRecommendation, query string) bool {
+	return strings.HasPrefix(strings.ToLower(string(rec)), strings.ToLower(strings.TrimSpace(query)))
+}
+
 // ApplyFilter sets search query and re-filters
 func (m *SessionListModel) ApplyFilter(query string) {
 	oldQuery := m.filterQuery
@@ -342,6 +367,11 @@ func (m *SessionListModel) matchesFilter(gs claudefs.GlobalSession, q string) bo
 
 	if queryLooksLikeLifecycleState(q) {
 		return claudefs.LifecycleStateMatchesQuery(s.Lifecycle.State, q)
+	}
+
+	if queryLooksLikeRecommendation(q) {
+		assessment := claudefs.QuickAssessSession(s)
+		return recommendationMatchesQuery(assessment.Recommendation, q)
 	}
 
 	if strings.Contains(strings.ToLower(s.ID), q) {

--- a/internal/ui/session_list_test.go
+++ b/internal/ui/session_list_test.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/kincoy/cc9s/internal/claudefs"
 )
@@ -153,5 +155,96 @@ func TestSessionListReloadFallsBackToPreviousIndex(t *testing.T) {
 
 	if model.cursor != 1 {
 		t.Fatalf("cursor = %d, want 1 after clamp", model.cursor)
+	}
+}
+
+func TestSessionListViewShowsCleanupHintsColumn(t *testing.T) {
+	model := &SessionListModel{
+		context: Context{Type: ContextAll},
+		sessions: []claudefs.GlobalSession{
+			{
+				ProjectName: "demo",
+				Session: claudefs.Session{
+					ID:           "stale-1",
+					Summary:      "tiny stale session",
+					LastActiveAt: time.Now().Add(-72 * time.Hour),
+					EventCount:   2,
+					FileSize:     500,
+					Lifecycle: claudefs.SessionLifecycleSnapshot{
+						State: claudefs.SessionLifecycleStale,
+					},
+				},
+			},
+		},
+		contextSessions: []claudefs.GlobalSession{
+			{
+				ProjectName: "demo",
+				Session: claudefs.Session{
+					ID:           "stale-1",
+					Summary:      "tiny stale session",
+					LastActiveAt: time.Now().Add(-72 * time.Hour),
+					EventCount:   2,
+					FileSize:     500,
+					Lifecycle: claudefs.SessionLifecycleSnapshot{
+						State: claudefs.SessionLifecycleStale,
+					},
+				},
+			},
+		},
+	}
+
+	model.SetCleanupHints(true)
+	out := model.View(140, 12)
+
+	for _, want := range []string{"RECOMMEND", "Delete"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cleanup hints output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSessionListRecommendationSearch(t *testing.T) {
+	model := &SessionListModel{}
+	sessions := []claudefs.GlobalSession{
+		{
+			ProjectName: "demo",
+			Session: claudefs.Session{
+				ID:           "s-001",
+				ProjectPath:  "/tmp/demo",
+				LastActiveAt: time.Now().Add(-72 * time.Hour),
+				EventCount:   2,
+				FileSize:     500,
+				Summary:      "hi",
+				Lifecycle: claudefs.SessionLifecycleSnapshot{
+					State: claudefs.SessionLifecycleStale,
+				},
+			},
+		},
+		{
+			ProjectName: "demo",
+			Session: claudefs.Session{
+				ID:           "s-002",
+				ProjectPath:  "/tmp/demo",
+				LastActiveAt: time.Now().Add(-2 * time.Hour),
+				EventCount:   300,
+				FileSize:     200000,
+				Summary:      "implement the full authentication system with JWT tokens",
+				Lifecycle: claudefs.SessionLifecycleSnapshot{
+					State: claudefs.SessionLifecycleCompleted,
+				},
+			},
+		},
+	}
+
+	model.contextSessions = sessions
+
+	model.ApplyFilter("del")
+	if len(model.sessions) != 1 || model.sessions[0].Session.ID != "s-001" {
+		t.Fatalf("delete recommendation search mismatch: %+v", model.sessions)
+	}
+
+	model.ApplyFilter("keep")
+	if len(model.sessions) != 1 || model.sessions[0].Session.ID != "s-002" {
+		t.Fatalf("keep recommendation search mismatch: %+v", model.sessions)
 	}
 }

--- a/internal/ui/session_table.go
+++ b/internal/ui/session_table.go
@@ -10,7 +10,7 @@ import (
 )
 
 // renderSessionTable renders the session table (Approach A: manually drawn borders, title embedded in top border)
-func renderSessionTable(sessions []claudefs.GlobalSession, cursor, width, height int, selectedRows map[int]struct{}, showProjectColumn bool, sortBy SessionSortField, sortAsc bool, contextLabel string) string {
+func renderSessionTable(sessions []claudefs.GlobalSession, cursor, width, height int, selectedRows map[int]struct{}, showProjectColumn bool, sortBy SessionSortField, sortAsc bool, contextLabel string, showCleanupHints bool) string {
 	if len(sessions) == 0 {
 		return ""
 	}
@@ -50,6 +50,7 @@ func renderSessionTable(sessions []claudefs.GlobalSession, cursor, width, height
 
 	idWidth := 12
 	statusWidth := 13
+	recommendWidth := 10
 	lastActiveWidth := 14
 	eventsWidth := 8
 	sizeWidth := 10
@@ -58,12 +59,18 @@ func renderSessionTable(sessions []claudefs.GlobalSession, cursor, width, height
 	if showProjectColumn {
 		colCount++
 	}
+	if showCleanupHints {
+		colCount++
+	}
 	if showEventsAndSize {
 		colCount += 2
 	}
 	sepCount := colCount - 1
 
 	fixedWidth := projectWidth + idWidth + statusWidth + lastActiveWidth
+	if showCleanupHints {
+		fixedWidth += recommendWidth
+	}
 	if showEventsAndSize {
 		fixedWidth += eventsWidth + sizeWidth
 	}
@@ -89,6 +96,7 @@ func renderSessionTable(sessions []claudefs.GlobalSession, cursor, width, height
 		{"SESSION ID", idWidth, lipgloss.Left, SortBySessionID, true},
 		{"SUMMARY", summaryWidth, lipgloss.Left, -1, true},
 		{"STATUS", statusWidth, lipgloss.Left, -1, true},
+		{"RECOMMEND", recommendWidth, lipgloss.Left, -1, showCleanupHints},
 		{"LAST ACTIVE", lastActiveWidth, lipgloss.Right, SortBySessionActivity, true},
 		{"EVENTS", eventsWidth, lipgloss.Right, SortByEventCount, showEventsAndSize},
 		{"SIZE", sizeWidth, lipgloss.Right, SortBySessionSize, showEventsAndSize},
@@ -142,6 +150,7 @@ func renderSessionTable(sessions []claudefs.GlobalSession, cursor, width, height
 
 		statusText := styles.LifecycleStatusText(gs.Session.Lifecycle.State)
 		statusStyle := styles.LifecycleStatusStyle(gs.Session.Lifecycle.State)
+		assessment := claudefs.QuickAssessSession(gs.Session)
 
 		rowSep := rowStyle.Render("  ")
 
@@ -156,17 +165,36 @@ func renderSessionTable(sessions []claudefs.GlobalSession, cursor, width, height
 				rowStyle.Width(projectWidth).Render(gs.ProjectName), rowSep,
 				rowStyle.Width(idWidth).Render(sessionID), rowSep,
 				rowStyle.Width(summaryWidth).Render(truncateSummary(summaryText, summaryWidth)), rowSep,
-				statusStyle.Inherit(rowStyle).Width(statusWidth).Render(statusText), rowSep,
-				rowStyle.Width(lastActiveWidth).Align(lipgloss.Right).Render(claudefs.FormatTimeAgo(gs.Session.LastActiveAt)),
+				statusStyle.Inherit(rowStyle).Width(statusWidth).Render(statusText),
 			)
 		} else {
 			rowParts = append(rowParts,
 				rowStyle.Width(idWidth).Render(sessionID), rowSep,
 				rowStyle.Width(summaryWidth).Render(truncateSummary(summaryText, summaryWidth)), rowSep,
-				statusStyle.Inherit(rowStyle).Width(statusWidth).Render(statusText), rowSep,
-				rowStyle.Width(lastActiveWidth).Align(lipgloss.Right).Render(claudefs.FormatTimeAgo(gs.Session.LastActiveAt)),
+				statusStyle.Inherit(rowStyle).Width(statusWidth).Render(statusText),
 			)
 		}
+
+		if showCleanupHints {
+			var recStyle lipgloss.Style
+			switch assessment.Recommendation {
+			case claudefs.RecommendDelete:
+				recStyle = rowStyle.Width(recommendWidth).Foreground(styles.ColorError)
+			case claudefs.RecommendMaybe:
+				recStyle = rowStyle.Width(recommendWidth).Foreground(styles.ColorWarning)
+			default:
+				recStyle = rowStyle.Width(recommendWidth).Foreground(styles.ColorActive)
+			}
+			rowParts = append(rowParts,
+				rowSep,
+				recStyle.Render(string(assessment.Recommendation)),
+			)
+		}
+
+		rowParts = append(rowParts,
+			rowSep,
+			rowStyle.Width(lastActiveWidth).Align(lipgloss.Right).Render(claudefs.FormatTimeAgo(gs.Session.LastActiveAt)),
+		)
 
 		if showEventsAndSize {
 			rowParts = append(rowParts,

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the user-facing version string shared between CLI and TUI.
-const Version = "0.2.1"
+const Version = "0.2.2"


### PR DESCRIPTION
- Add session value assessment engine (full + lightweight) in internal/claudefs/
- Score sessions on conversation depth, tool usage, token investment, file size
- Three recommendation tiers: Delete (safe to remove), Maybe (review), Keep (valuable)
- CLI `sessions cleanup --dry-run` now shows grouped recommendations with reasons
- TUI `:cleanup` command toggles RECOMMEND column in session table
- TUI search supports filtering by recommendation tier (e.g. /delete, /keep)
- Bump version to v0.2.2