### PR TITLE
allow config executable using envvar

### DIFF
--- a/internal/claudefs/agent_recognition.go
+++ b/internal/claudefs/agent_recognition.go
@@ -2,6 +2,7 @@ package claudefs
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -17,13 +18,22 @@ var runClaudeAgentsCommand = defaultRunClaudeAgentsCommand
 
 var activeAgentsLinePattern = regexp.MustCompile(`^\d+\s+active agents$`)
 
+// GetClaudeExec returns the Claude executable path.
+// Checks the CC9S_CLAUDE_EXEC environment variable, and fallback to "claude" if not set.
+func GetClaudeExec() string {
+	if exec := os.Getenv("CC9S_CLAUDE_EXEC"); exec != "" {
+		return exec
+	}
+	return "claude"
+}
+
 func defaultRunClaudeAgentsCommand(workDir string, settingSources string) (string, error) {
 	args := []string{"agents"}
 	if strings.TrimSpace(settingSources) != "" {
 		args = append(args, "--setting-sources", settingSources)
 	}
 
-	cmd := exec.Command("claude", args...)
+	cmd := exec.Command(GetClaudeExec(), args...)
 	if strings.TrimSpace(workDir) != "" {
 		cmd.Dir = workDir
 	}

--- a/internal/ui/session_list.go
+++ b/internal/ui/session_list.go
@@ -683,7 +683,7 @@ func resumeSessionCmd(session claudefs.Session) tea.Cmd {
 	return func() tea.Msg {
 		clearScreen()
 
-		cmd := exec.Command("claude", "--resume", session.ID)
+		cmd := exec.Command(claudefs.GetClaudeExec(), "--resume", session.ID)
 		cmd.Dir = session.ProjectPath
 
 		var stderr bytes.Buffer


### PR DESCRIPTION
Allow using non-standard claude executable name, in case you want to modify the default cli options / create a wrapper around claude

I see you had a configuration on road map, maybe adding this as configure option is the better way, but I'll just leave the pr here anyway.