### PR TITLE
feat: add `r` keybinding to refresh current resource

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -558,6 +558,11 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return SwitchContextMsg{Context: Context{Type: ContextAll}}
 				}
 			}
+		case "r":
+			if a.isLoading {
+				return a, nil
+			}
+			return a, a.refreshCurrentResource()
 		}
 	}
 
@@ -567,7 +572,7 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var forwardedCmd tea.Cmd
 	var isLoadedMsg bool
 	if _, ok := msg.(projectsLoadedMsg); ok {
-		a.projectList.Update(msg)
+		forwardedCmd = a.projectList.Update(msg)
 		isLoadedMsg = true
 	}
 	if _, ok := msg.(skillsLoadedMsg); ok && a.skillList != nil {
@@ -959,6 +964,35 @@ func (a *AppModel) updateCurrentView(msg tea.Msg) tea.Cmd {
 		}
 	}
 	return nil
+}
+
+func (a *AppModel) refreshCurrentResource() tea.Cmd {
+	a.isLoading = true
+	a.loadingResource = a.currentResource
+	a.loadingText = "Refreshing..."
+
+	var reloadCmd tea.Cmd
+	switch a.currentResource {
+	case ResourceProjects:
+		reloadCmd = a.projectList.Reload()
+	case ResourceSessions:
+		if a.sessionList != nil {
+			reloadCmd = a.sessionList.Reload()
+		}
+	case ResourceSkills:
+		if a.skillList != nil {
+			reloadCmd = a.skillList.Reload()
+		}
+	case ResourceAgents:
+		if a.agentList != nil {
+			reloadCmd = a.agentList.Reload()
+		}
+	}
+	if reloadCmd == nil {
+		a.isLoading = false
+		return nil
+	}
+	return tea.Batch(reloadCmd, a.spinner.Tick)
 }
 
 func (a *AppModel) syncDetailOverlaysAfterLoad(msg tea.Msg) {

--- a/internal/ui/project_list.go
+++ b/internal/ui/project_list.go
@@ -58,6 +58,12 @@ func (m *ProjectListModel) Init() tea.Cmd {
 	)
 }
 
+// Reload rescans projects from disk.
+func (m *ProjectListModel) Reload() tea.Cmd {
+	m.loading = true
+	return scanProjectsCmd
+}
+
 // scanProjectsCmd asynchronously scans projects
 func scanProjectsCmd() tea.Msg {
 	result := claudefs.ScanProjects()
@@ -87,6 +93,7 @@ func (m *ProjectListModel) Update(msg tea.Msg) tea.Cmd {
 			m.cursor = 0
 		}
 		m.updateViewportContent()
+		return func() tea.Msg { return StopLoadingMsg{Resource: ResourceProjects} }
 
 	case tea.KeyPressMsg:
 		switch msg.String() {

--- a/internal/ui/resource_registry.go
+++ b/internal/ui/resource_registry.go
@@ -25,6 +25,7 @@ func newResourceRegistry() *ResourceRegistry {
 					{Key: "q", Label: "Quit"},
 					{Key: "j/k", Label: "Navigate"},
 					{Key: "s/S", Label: "Sort"},
+					{Key: "r", Label: "Refresh"},
 					{Key: "Enter", Label: "Open"},
 					{Key: ":", Label: "Cmd"},
 					{Key: "?", Label: "Help"},
@@ -45,6 +46,7 @@ func newResourceRegistry() *ResourceRegistry {
 						{Key: ":health", Label: "      Toggle HEALTH column"},
 						{Key: "Enter", Label: "     Open selected project sessions"},
 						{Key: "d", Label: "         View selected project details"},
+						{Key: "r", Label: "         Refresh data from disk"},
 						{Key: "/", Label: "         Search projects by name or path"},
 					},
 				}
@@ -101,6 +103,7 @@ func newResourceRegistry() *ResourceRegistry {
 					{Key: "q", Label: "Quit"},
 					{Key: "j/k", Label: "Navigate"},
 					{Key: "s/S", Label: "Sort"},
+					{Key: "r", Label: "Refresh"},
 					{Key: "Enter", Label: "Resume"},
 					{Key: "Space", Label: "Select"},
 					{Key: ":", Label: "Cmd"},
@@ -133,6 +136,7 @@ func newResourceRegistry() *ResourceRegistry {
 						{Key: "Enter", Label: "     Resume selected session"},
 						{Key: "d", Label: "         View session details"},
 						{Key: "l", Label: "         View session log"},
+						{Key: "r", Label: "         Refresh data from disk"},
 						{Key: "/", Label: "         Search sessions or lifecycle states"},
 						{Key: "Esc", Label: "       Go back to projects"},
 						{Key: "Space", Label: "      Toggle select session"},
@@ -222,6 +226,7 @@ func newResourceRegistry() *ResourceRegistry {
 						{Key: ":skills", Label: "    Switch to skills resource"},
 						{Key: "d", Label: "         View selected skill or command details"},
 						{Key: "e", Label: "         Edit selected skill or command"},
+						{Key: "r", Label: "         Refresh data from disk"},
 						{Key: "/", Label: "         Search skills and commands by name, path, scope, status"},
 					},
 				}
@@ -307,6 +312,7 @@ func newResourceRegistry() *ResourceRegistry {
 						{Key: ":agents", Label: "    Switch to agents resource"},
 						{Key: "d", Label: "         View selected agent details"},
 						{Key: "e", Label: "         Edit selected agent file"},
+						{Key: "r", Label: "         Refresh data from disk"},
 						{Key: "/", Label: "         Search agents by name, path, scope, status, config"},
 					},
 				}
@@ -425,6 +431,7 @@ func defaultResourceFooterHints(ctx FooterContext) []KeyHint {
 		{Key: "q", Label: "Quit"},
 		{Key: "j/k", Label: "Navigate"},
 		{Key: "s/S", Label: "Sort"},
+		{Key: "r", Label: "Refresh"},
 		{Key: ":", Label: "Cmd"},
 		{Key: "?", Label: "Help"},
 	}


### PR DESCRIPTION
## Summary

- Adds `r` as a global keybinding to refresh data in all four resource views (Projects, Sessions, Skills, Agents)
- Adds `ProjectListModel.Reload()` method (was the only view missing one)
- Returns `StopLoadingMsg` from project scan completion to properly stop the loading spinner
- Fixes a pre-existing bug where `projectsLoadedMsg` return value was discarded in `app.go`, causing the spinner to never stop
- Adds `<r> Refresh` to footer hints and help panel for all views

## Motivation

Currently there is no way to refresh data without restarting cc9s. When files are edited externally (e.g., fixing agent frontmatter, creating new skills), users must quit and relaunch to see updated status. This PR adds the standard `r` refresh keybinding, consistent with k9s conventions.

## Changes

| File | Change |
|------|--------|
| `internal/ui/app.go` | Add `"r"` key handler + `refreshCurrentResource()` method; fix discarded `projectsLoadedMsg` return value |
| `internal/ui/project_list.go` | Add `Reload()` method + `StopLoadingMsg` return from scan completion |
| `internal/ui/resource_registry.go` | Add `{Key: "r", Label: "Refresh"}` to all footer hints + help sections |

## Test plan

- [x] `go build` compiles successfully
- [x] `go test ./...` all tests pass
- [x] Manual: press `r` on Projects view — spinner appears, data refreshes
- [x] Manual: press `r` on Sessions/Skills/Agents views — same behavior
- [x] Manual: press `r` while already loading — no-op (no double refresh)
- [x] Manual: footer shows `<r> Refresh` on all views
- [x] Manual: `?` help panel shows refresh keybinding info