### PR TITLE
feat: add arrow key navigation between resource tabs

### DIFF
--- a/internal/claudefs/scanner.go
+++ b/internal/claudefs/scanner.go
@@ -72,6 +72,14 @@ func scanProjectsDir(projectsDir string, activeMarkers map[string]activeSessionI
 			// JSONL fallback: read cwd from a JSONL file in the project directory
 			decodedPath = extractCwdFromProjectDir(filepath.Join(projectsDir, encodedPath))
 		}
+
+		// Skip projects whose working directory no longer exists on disk
+		if decodedPath != "" {
+			if _, err := os.Stat(decodedPath); os.IsNotExist(err) {
+				continue
+			}
+		}
+
 		projectName := ExtractProjectName(decodedPath)
 
 		// Scan session files under this project

--- a/internal/claudefs/scanner.go
+++ b/internal/claudefs/scanner.go
@@ -74,6 +74,14 @@ func scanProjectsDir(projectsDir string, activeMarkers map[string]activeSessionI
 		}
 		projectName := ExtractProjectName(decodedPath)
 
+		// Check whether the project working directory still exists on disk
+		pathExists := false
+		if decodedPath != "" {
+			if _, err := os.Stat(decodedPath); err == nil {
+				pathExists = true
+			}
+		}
+
 		// Scan session files under this project
 		projectDir := filepath.Join(projectsDir, encodedPath)
 		sessionCount, totalSize, lastActive, projectActiveCount := scanProjectSessions(projectDir, activeMarkers, now)
@@ -94,6 +102,7 @@ func scanProjectsDir(projectsDir string, activeMarkers map[string]activeSessionI
 				HasSkillsRoot:      resourceSummary.HasSkillsRoot,
 				HasCommandsRoot:    resourceSummary.HasCommandsRoot,
 				HasAgentsRoot:      resourceSummary.HasAgentsRoot,
+				PathExists:         pathExists,
 			})
 			totalSessions += sessionCount
 			activeCount += projectActiveCount

--- a/internal/claudefs/types.go
+++ b/internal/claudefs/types.go
@@ -48,6 +48,7 @@ type Project struct {
 	HasSkillsRoot      bool      // Whether .claude/skills exists
 	HasCommandsRoot    bool      // Whether .claude/commands exists
 	HasAgentsRoot      bool      // Whether .claude/agents exists
+	PathExists         bool      // Whether the project working directory still exists on disk
 }
 
 // Session represents a Claude Code session.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -558,6 +558,11 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return SwitchContextMsg{Context: Context{Type: ContextAll}}
 				}
 			}
+		case "r":
+			if a.isLoading {
+				return a, nil
+			}
+			return a, a.refreshCurrentResource()
 		}
 	}
 
@@ -567,7 +572,7 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var forwardedCmd tea.Cmd
 	var isLoadedMsg bool
 	if _, ok := msg.(projectsLoadedMsg); ok {
-		a.projectList.Update(msg)
+		forwardedCmd = a.projectList.Update(msg)
 		isLoadedMsg = true
 	}
 	if _, ok := msg.(skillsLoadedMsg); ok && a.skillList != nil {
@@ -959,6 +964,35 @@ func (a *AppModel) updateCurrentView(msg tea.Msg) tea.Cmd {
 		}
 	}
 	return nil
+}
+
+func (a *AppModel) refreshCurrentResource() tea.Cmd {
+	a.isLoading = true
+	a.loadingResource = a.currentResource
+	a.loadingText = "Refreshing..."
+
+	var reloadCmd tea.Cmd
+	switch a.currentResource {
+	case ResourceProjects:
+		reloadCmd = a.projectList.Reload()
+	case ResourceSessions:
+		if a.sessionList != nil {
+			reloadCmd = a.sessionList.Reload()
+		}
+	case ResourceSkills:
+		if a.skillList != nil {
+			reloadCmd = a.skillList.Reload()
+		}
+	case ResourceAgents:
+		if a.agentList != nil {
+			reloadCmd = a.agentList.Reload()
+		}
+	}
+	if reloadCmd == nil {
+		a.isLoading = false
+		return nil
+	}
+	return tea.Batch(reloadCmd, a.spinner.Tick)
 }
 
 func (a *AppModel) syncDetailOverlaysAfterLoad(msg tea.Msg) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -563,6 +563,18 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			}
 			return a, a.refreshCurrentResource()
+		case "left":
+			if a.showHelp {
+				return a, nil
+			}
+			next := a.tabs.PrevResource()
+			return a, func() tea.Msg { return SwitchResourceMsg{Resource: next} }
+		case "right":
+			if a.showHelp {
+				return a, nil
+			}
+			next := a.tabs.NextResource()
+			return a, func() tea.Msg { return SwitchResourceMsg{Resource: next} }
 		}
 	}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1148,6 +1148,7 @@ func (a *AppModel) commandCompletionCandidates(input string, excludeExact bool) 
 		commands := append(a.resourceRegistry.CompletionCandidates(prefix), "context")
 		if a.currentResource == ResourceProjects {
 			commands = append(commands, "health")
+			commands = append(commands, "cleanup")
 		}
 		if a.currentResource == ResourceSessions {
 			commands = append(commands, "cleanup")
@@ -1251,6 +1252,10 @@ func (a *AppModel) executeCommand(cmdStr string) tea.Cmd {
 	case "cleanup":
 		if a.currentResource == ResourceSessions {
 			return func() tea.Msg { return ToggleCleanupHintsMsg{} }
+		}
+		if a.currentResource == ResourceProjects && a.projectList != nil {
+			a.projectList.showCleanupColumn = !a.projectList.showCleanupColumn
+			a.projectList.updateViewportContent()
 		}
 		return nil
 	case "health":

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -480,7 +480,7 @@ func TestCleanupCommandTogglesSessionCleanupHints(t *testing.T) {
 	}
 }
 
-func TestCleanupCommandCompletionOnlyInSessions(t *testing.T) {
+func TestCleanupCommandCompletionInSessionsAndProjects(t *testing.T) {
 	app := NewAppModel()
 	app.setActiveResource(ResourceSessions)
 
@@ -498,9 +498,22 @@ func TestCleanupCommandCompletionOnlyInSessions(t *testing.T) {
 
 	app.setActiveResource(ResourceProjects)
 	candidates, _, _ = app.commandCompletionCandidates("cl", false)
+	found = false
 	for _, candidate := range candidates {
 		if candidate == "cleanup" {
-			t.Fatalf("cleanup should not complete outside sessions, got %#v", candidates)
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected cleanup completion in projects, got %#v", candidates)
+	}
+
+	app.setActiveResource(ResourceSkills)
+	candidates, _, _ = app.commandCompletionCandidates("cl", false)
+	for _, candidate := range candidates {
+		if candidate == "cleanup" {
+			t.Fatalf("cleanup should not complete outside sessions/projects, got %#v", candidates)
 		}
 	}
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -36,6 +36,8 @@ func buildHelpLines(registry *ResourceRegistry, active ResourceDescriptor) []str
 		"  " + styles.FooterKeyStyle.Render("Ctrl+U") + styles.FooterStyle.Render("   Scroll half-page up"),
 		"  " + styles.FooterKeyStyle.Render("PgDn") + styles.FooterStyle.Render("     Scroll page down"),
 		"  " + styles.FooterKeyStyle.Render("PgUp") + styles.FooterStyle.Render("     Scroll page up"),
+		"  " + styles.FooterKeyStyle.Render("← / →") + styles.FooterStyle.Render("     Switch resource tab"),
+		"  " + styles.FooterKeyStyle.Render("1-4") + styles.FooterStyle.Render("       Switch to resource tab"),
 		"",
 		"  " + styles.HeaderStyle.Render("Sorting"),
 		"  " + styles.FooterKeyStyle.Render("s") + styles.FooterStyle.Render("         Cycle sort field"),

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -38,8 +38,8 @@ func TestRenderHelpUsesRegistryCommandNamesAndActiveCapabilities(t *testing.T) {
 	if !strings.Contains(output, ":cleanup") {
 		t.Fatal("expected projects help to include cleanup command guidance")
 	}
-	if !strings.Contains(output, "Toggle cleanup recommendations") {
-		t.Fatal("expected projects help to describe cleanup recommendations")
+	if !strings.Contains(output, "Toggle STATUS column") {
+		t.Fatal("expected projects help to describe cleanup STATUS column")
 	}
 	if !strings.Contains(output, "Switch to all projects") {
 		t.Fatal("expected projects help to include all-context shortcut guidance")

--- a/internal/ui/project_list.go
+++ b/internal/ui/project_list.go
@@ -37,8 +37,9 @@ type ProjectListModel struct {
 	lastWidth     int                // last rendered width, used to match visible sort columns
 	totalSessions int                // total session count
 	activeCount   int                // active session count
-	showHealthColumn bool
-	projectHealth    map[string]int // projectName -> healthScore
+	showHealthColumn  bool
+	showCleanupColumn bool
+	projectHealth     map[string]int // projectName -> healthScore
 }
 
 // NewProjectListModel creates a new project list Model
@@ -210,7 +211,7 @@ func (m *ProjectListModel) updateViewportContent() {
 		height = 20 // default height if not yet sized
 	}
 
-	content := renderProjectTable(m.projects, m.cursor, width, height, m.sortBy, m.sortAsc, m.showHealthColumn, m.projectHealth, m.filterQuery)
+	content := renderProjectTable(m.projects, m.cursor, width, height, m.sortBy, m.sortAsc, m.showHealthColumn, m.showCleanupColumn, m.projectHealth, m.filterQuery)
 	m.viewport.SetContent(content)
 }
 

--- a/internal/ui/project_list.go
+++ b/internal/ui/project_list.go
@@ -58,6 +58,12 @@ func (m *ProjectListModel) Init() tea.Cmd {
 	)
 }
 
+// Reload rescans projects from disk.
+func (m *ProjectListModel) Reload() tea.Cmd {
+	m.loading = true
+	return scanProjectsCmd
+}
+
 // scanProjectsCmd asynchronously scans projects
 func scanProjectsCmd() tea.Msg {
 	result := claudefs.ScanProjects()
@@ -87,6 +93,7 @@ func (m *ProjectListModel) Update(msg tea.Msg) tea.Cmd {
 			m.cursor = 0
 		}
 		m.updateViewportContent()
+		return func() tea.Msg { return StopLoadingMsg{Resource: ResourceProjects} }
 
 	case tea.KeyPressMsg:
 		switch msg.String() {

--- a/internal/ui/resource_registry.go
+++ b/internal/ui/resource_registry.go
@@ -24,6 +24,7 @@ func newResourceRegistry() *ResourceRegistry {
 				hints := []KeyHint{
 					{Key: "q", Label: "Quit"},
 					{Key: "j/k", Label: "Navigate"},
+					{Key: "←/→", Label: "Tabs"},
 					{Key: "s/S", Label: "Sort"},
 					{Key: "r", Label: "Refresh"},
 					{Key: "Enter", Label: "Open"},
@@ -103,6 +104,7 @@ func newResourceRegistry() *ResourceRegistry {
 				hints := []KeyHint{
 					{Key: "q", Label: "Quit"},
 					{Key: "j/k", Label: "Navigate"},
+					{Key: "←/→", Label: "Tabs"},
 					{Key: "s/S", Label: "Sort"},
 					{Key: "r", Label: "Refresh"},
 					{Key: "Enter", Label: "Resume"},
@@ -431,6 +433,7 @@ func defaultResourceFooterHints(ctx FooterContext) []KeyHint {
 	hints := []KeyHint{
 		{Key: "q", Label: "Quit"},
 		{Key: "j/k", Label: "Navigate"},
+		{Key: "←/→", Label: "Tabs"},
 		{Key: "s/S", Label: "Sort"},
 		{Key: "r", Label: "Refresh"},
 		{Key: ":", Label: "Cmd"},

--- a/internal/ui/resource_registry.go
+++ b/internal/ui/resource_registry.go
@@ -43,6 +43,7 @@ func newResourceRegistry() *ResourceRegistry {
 					Lines: []KeyHint{
 						{Key: ":projects", Label: "    Switch to projects resource"},
 						{Key: ":health", Label: "      Toggle HEALTH column"},
+						{Key: ":cleanup", Label: "     Toggle STATUS column (deleted projects)"},
 						{Key: "Enter", Label: "     Open selected project sessions"},
 						{Key: "d", Label: "         View selected project details"},
 						{Key: "/", Label: "         Search projects by name or path"},

--- a/internal/ui/resource_registry.go
+++ b/internal/ui/resource_registry.go
@@ -25,6 +25,7 @@ func newResourceRegistry() *ResourceRegistry {
 					{Key: "q", Label: "Quit"},
 					{Key: "j/k", Label: "Navigate"},
 					{Key: "s/S", Label: "Sort"},
+					{Key: "r", Label: "Refresh"},
 					{Key: "Enter", Label: "Open"},
 					{Key: ":", Label: "Cmd"},
 					{Key: "?", Label: "Help"},
@@ -45,6 +46,7 @@ func newResourceRegistry() *ResourceRegistry {
 						{Key: ":health", Label: "      Toggle HEALTH column"},
 						{Key: "Enter", Label: "     Open selected project sessions"},
 						{Key: "d", Label: "         View selected project details"},
+						{Key: "r", Label: "         Refresh data from disk"},
 						{Key: "/", Label: "         Search projects by name or path"},
 					},
 				}
@@ -101,6 +103,7 @@ func newResourceRegistry() *ResourceRegistry {
 					{Key: "q", Label: "Quit"},
 					{Key: "j/k", Label: "Navigate"},
 					{Key: "s/S", Label: "Sort"},
+					{Key: "r", Label: "Refresh"},
 					{Key: "Enter", Label: "Resume"},
 					{Key: "Space", Label: "Select"},
 					{Key: ":", Label: "Cmd"},
@@ -133,6 +136,7 @@ func newResourceRegistry() *ResourceRegistry {
 						{Key: "Enter", Label: "     Resume selected session"},
 						{Key: "d", Label: "         View session details"},
 						{Key: "l", Label: "         View session log"},
+						{Key: "r", Label: "         Refresh data from disk"},
 						{Key: "/", Label: "         Search sessions or lifecycle states"},
 						{Key: "Esc", Label: "       Go back to projects"},
 						{Key: "Space", Label: "      Toggle select session"},
@@ -222,6 +226,7 @@ func newResourceRegistry() *ResourceRegistry {
 						{Key: ":skills", Label: "    Switch to skills resource"},
 						{Key: "d", Label: "         View selected skill or command details"},
 						{Key: "e", Label: "         Edit selected skill or command"},
+						{Key: "r", Label: "         Refresh data from disk"},
 						{Key: "/", Label: "         Search skills and commands by name, path, scope, status"},
 					},
 				}
@@ -307,6 +312,7 @@ func newResourceRegistry() *ResourceRegistry {
 						{Key: ":agents", Label: "    Switch to agents resource"},
 						{Key: "d", Label: "         View selected agent details"},
 						{Key: "e", Label: "         Edit selected agent file"},
+						{Key: "r", Label: "         Refresh data from disk"},
 						{Key: "/", Label: "         Search agents by name, path, scope, status, config"},
 					},
 				}
@@ -425,6 +431,7 @@ func defaultResourceFooterHints(ctx FooterContext) []KeyHint {
 		{Key: "q", Label: "Quit"},
 		{Key: "j/k", Label: "Navigate"},
 		{Key: "s/S", Label: "Sort"},
+		{Key: "r", Label: "Refresh"},
 		{Key: ":", Label: "Cmd"},
 		{Key: "?", Label: "Help"},
 	}

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -11,7 +11,7 @@ import (
 )
 
 // renderProjectTable renders the project table (Approach A: manually drawn borders, title embedded in top border)
-func renderProjectTable(projects []claudefs.Project, cursor, width, height int, sortBy SortField, sortAsc bool, showHealthColumn bool, projectHealth map[string]int, searchPattern string) string {
+func renderProjectTable(projects []claudefs.Project, cursor, width, height int, sortBy SortField, sortAsc bool, showHealthColumn bool, showCleanupColumn bool, projectHealth map[string]int, searchPattern string) string {
 	if len(projects) == 0 {
 		return renderEmptyState(width, height)
 	}
@@ -45,6 +45,10 @@ func renderProjectTable(projects []claudefs.Project, cursor, width, height int, 
 	if showHealthColumn {
 		healthWidth = 8
 	}
+	cleanupWidth := 0
+	if showCleanupColumn {
+		cleanupWidth = 10
+	}
 
 	sepCount := 5
 	if showPath {
@@ -56,9 +60,12 @@ func renderProjectTable(projects []claudefs.Project, cursor, width, height int, 
 	if showHealthColumn {
 		sepCount++
 	}
+	if showCleanupColumn {
+		sepCount++
+	}
 	sepWidth := sepCount * 2
 
-	fixedWidth := sessionsWidth + skillsWidth + agentsWidth + lastActiveWidth + healthWidth + sepWidth
+	fixedWidth := sessionsWidth + skillsWidth + agentsWidth + lastActiveWidth + healthWidth + cleanupWidth + sepWidth
 	if showSize {
 		fixedWidth += sizeWidth
 	}
@@ -92,6 +99,7 @@ func renderProjectTable(projects []claudefs.Project, cursor, width, height int, 
 		{"LOCAL AG", agentsWidth, lipgloss.Right, SortByAgentCount},
 		{"LAST ACTIVE", lastActiveWidth, lipgloss.Right, SortByActivity},
 		{"HEALTH", healthWidth, lipgloss.Right, SortByHealth},
+		{"STATUS", cleanupWidth, lipgloss.Left, -1},
 		{"SIZE", sizeWidth, lipgloss.Right, SortBySize},
 	}
 	visibleHeaders := make([]struct {
@@ -108,6 +116,9 @@ func renderProjectTable(projects []claudefs.Project, cursor, width, height int, 
 			continue
 		}
 		if h.text == "HEALTH" && !showHealthColumn {
+			continue
+		}
+		if h.text == "STATUS" && !showCleanupColumn {
 			continue
 		}
 		visibleHeaders = append(visibleHeaders, h)
@@ -205,6 +216,24 @@ func renderProjectTable(projects []claudefs.Project, cursor, width, height int, 
 			rowParts = append(rowParts,
 				rowSep,
 				healthField,
+			)
+		}
+		if showCleanupColumn {
+			statusText := "OK"
+			statusColor := styles.ColorActive
+			if !project.PathExists {
+				statusText = "Deleted"
+				statusColor = styles.ColorError
+			}
+			statusField := lipgloss.NewStyle().
+				Foreground(statusColor).
+				Inherit(rowStyle).
+				Width(cleanupWidth).
+				Align(lipgloss.Left).
+				Render(statusText)
+			rowParts = append(rowParts,
+				rowSep,
+				statusField,
 			)
 		}
 		if showSize {

--- a/internal/ui/tabs.go
+++ b/internal/ui/tabs.go
@@ -29,6 +29,24 @@ func (t *TabsModel) SetCurrent(r ResourceType) {
 	t.current = r
 }
 
+func (t *TabsModel) NextResource() ResourceType {
+	for i, r := range tabResources {
+		if r == t.current {
+			return tabResources[(i+1)%len(tabResources)]
+		}
+	}
+	return t.current
+}
+
+func (t *TabsModel) PrevResource() ResourceType {
+	for i, r := range tabResources {
+		if r == t.current {
+			return tabResources[(i-1+len(tabResources))%len(tabResources)]
+		}
+	}
+	return t.current
+}
+
 // TabsHeight is the vertical space consumed by the tab bar.
 const TabsHeight = 2
 


### PR DESCRIPTION
## Summary

- Add `←`/`→` arrow key navigation to cycle between the four top-level resource tabs (Projects → Sessions → Skills → Agents) with wrap-around, without entering command mode
- Arrow keys are no-ops during search mode, command mode, help overlay, and dialog overlays
- Help screen (`?`) and footer hints updated to document the new keybinding

Closes #31

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass (including 3 new unit tests for wrap-around logic and footer hints)
- [x] Manual testing: `→` cycles forward through tabs with wrap-around
- [x] Manual testing: `←` cycles backward through tabs with wrap-around
- [x] Arrow keys are no-op in search mode (`/`)
- [x] Arrow keys are no-op in help overlay (`?`)
- [x] Lazy loading triggers correctly on first arrow-key switch to Sessions/Skills/Agents
- [x] Footer shows `←/→ Tabs` hint in all views
- [x] Help screen shows `← / →` and `1-4` in Navigation section
- [x] Existing `↑`/`↓`, `j`/`k`, `1-4` bindings unaffected