### PR TITLE
feat: add arrow key navigation between resource tabs

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -563,6 +563,18 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			}
 			return a, a.refreshCurrentResource()
+		case "left":
+			if a.showHelp {
+				return a, nil
+			}
+			next := a.tabs.PrevResource()
+			return a, func() tea.Msg { return SwitchResourceMsg{Resource: next} }
+		case "right":
+			if a.showHelp {
+				return a, nil
+			}
+			next := a.tabs.NextResource()
+			return a, func() tea.Msg { return SwitchResourceMsg{Resource: next} }
 		}
 	}
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -36,6 +36,8 @@ func buildHelpLines(registry *ResourceRegistry, active ResourceDescriptor) []str
 		"  " + styles.FooterKeyStyle.Render("Ctrl+U") + styles.FooterStyle.Render("   Scroll half-page up"),
 		"  " + styles.FooterKeyStyle.Render("PgDn") + styles.FooterStyle.Render("     Scroll page down"),
 		"  " + styles.FooterKeyStyle.Render("PgUp") + styles.FooterStyle.Render("     Scroll page up"),
+		"  " + styles.FooterKeyStyle.Render("← / →") + styles.FooterStyle.Render("     Switch resource tab"),
+		"  " + styles.FooterKeyStyle.Render("1-4") + styles.FooterStyle.Render("       Switch to resource tab"),
 		"",
 		"  " + styles.HeaderStyle.Render("Sorting"),
 		"  " + styles.FooterKeyStyle.Render("s") + styles.FooterStyle.Render("         Cycle sort field"),

--- a/internal/ui/resource_registry.go
+++ b/internal/ui/resource_registry.go
@@ -24,6 +24,7 @@ func newResourceRegistry() *ResourceRegistry {
 				hints := []KeyHint{
 					{Key: "q", Label: "Quit"},
 					{Key: "j/k", Label: "Navigate"},
+					{Key: "←/→", Label: "Tabs"},
 					{Key: "s/S", Label: "Sort"},
 					{Key: "r", Label: "Refresh"},
 					{Key: "Enter", Label: "Open"},
@@ -102,6 +103,7 @@ func newResourceRegistry() *ResourceRegistry {
 				hints := []KeyHint{
 					{Key: "q", Label: "Quit"},
 					{Key: "j/k", Label: "Navigate"},
+					{Key: "←/→", Label: "Tabs"},
 					{Key: "s/S", Label: "Sort"},
 					{Key: "r", Label: "Refresh"},
 					{Key: "Enter", Label: "Resume"},
@@ -430,6 +432,7 @@ func defaultResourceFooterHints(ctx FooterContext) []KeyHint {
 	hints := []KeyHint{
 		{Key: "q", Label: "Quit"},
 		{Key: "j/k", Label: "Navigate"},
+		{Key: "←/→", Label: "Tabs"},
 		{Key: "s/S", Label: "Sort"},
 		{Key: "r", Label: "Refresh"},
 		{Key: ":", Label: "Cmd"},

--- a/internal/ui/tabs.go
+++ b/internal/ui/tabs.go
@@ -29,6 +29,24 @@ func (t *TabsModel) SetCurrent(r ResourceType) {
 	t.current = r
 }
 
+func (t *TabsModel) NextResource() ResourceType {
+	for i, r := range tabResources {
+		if r == t.current {
+			return tabResources[(i+1)%len(tabResources)]
+		}
+	}
+	return t.current
+}
+
+func (t *TabsModel) PrevResource() ResourceType {
+	for i, r := range tabResources {
+		if r == t.current {
+			return tabResources[(i-1+len(tabResources))%len(tabResources)]
+		}
+	}
+	return t.current
+}
+
 // TabsHeight is the vertical space consumed by the tab bar.
 const TabsHeight = 2
 


### PR DESCRIPTION
## Summary

- Add `←`/`→` arrow key navigation to cycle between the four top-level resource tabs (Projects → Sessions → Skills → Agents) with wrap-around, without entering command mode
- Arrow keys are no-ops during search mode, command mode, help overlay, and dialog overlays
- Help screen (`?`) and footer hints updated to document the new keybinding

Closes #31

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] Manual testing: `→` cycles forward through tabs with wrap-around (Agents → Projects)
- [x] Manual testing: `←` cycles backward through tabs with wrap-around (Projects → Agents)
- [x] Arrow keys are no-op in search mode (`/`)
- [x] Arrow keys are no-op in help overlay (`?`)
- [x] Lazy loading triggers correctly on first arrow-key switch to Sessions/Skills/Agents
- [x] Footer shows `←/→ Tabs` hint in all views
- [x] Help screen shows `← / →` and `1-4` in Navigation section
- [x] Existing `↑`/`↓`, `j`/`k`, `1-4` bindings unaffected