### PR TITLE
[refactor] centralize Claude data directory paths with --claude-dir support

### DIFF
--- a/internal/claudefs/agent_scanner.go
+++ b/internal/claudefs/agent_scanner.go
@@ -48,14 +48,9 @@ func ScanAgents() AgentScanResult {
 }
 
 func getAgentDiscoveryRoots() ([]AgentDiscoveryRoot, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-
 	roots := make([]AgentDiscoveryRoot, 0, 4)
 	roots = append(roots, AgentDiscoveryRoot{
-		Path:   filepath.Join(homeDir, ".claude", "agents"),
+		Path:   AgentsDir(),
 		Source: AgentSourceUser,
 	})
 
@@ -76,7 +71,7 @@ func getAgentDiscoveryRoots() ([]AgentDiscoveryRoot, error) {
 		})
 	}
 
-	pluginRoots, err := getInstalledAgentDiscoveryRoots(homeDir)
+	pluginRoots, err := getInstalledAgentDiscoveryRoots()
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +80,8 @@ func getAgentDiscoveryRoots() ([]AgentDiscoveryRoot, error) {
 	return uniqueAgentDiscoveryRoots(roots), nil
 }
 
-func getInstalledAgentDiscoveryRoots(homeDir string) ([]AgentDiscoveryRoot, error) {
-	installedPath := filepath.Join(homeDir, ".claude", "plugins", "installed_plugins.json")
+func getInstalledAgentDiscoveryRoots() ([]AgentDiscoveryRoot, error) {
+	installedPath := PluginsInstalledPath()
 	data, err := os.ReadFile(installedPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/claudefs/analytics.go
+++ b/internal/claudefs/analytics.go
@@ -7,8 +7,7 @@ import (
 )
 
 // ComputeHealthMetrics calculates environment-wide health insights.
-func ComputeHealthMetrics(homeDir string) (HealthMetrics, error) {
-	_ = homeDir
+func ComputeHealthMetrics() (HealthMetrics, error) {
 
 	scanResult := ScanProjects()
 	if scanResult.Err != nil {

--- a/internal/claudefs/delete.go
+++ b/internal/claudefs/delete.go
@@ -17,16 +17,11 @@ type DeleteTarget struct {
 
 // DeleteSession deletes a single session (JSONL file + active marker)
 func DeleteSession(target DeleteTarget) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("get home dir: %w", err)
-	}
-
-	projectDir := filepath.Join(homeDir, ".claude", "projects", target.EncodedPath)
+	projectDir := filepath.Join(ProjectsDir(), target.EncodedPath)
 
 	// Validate path does not escape the allowed directory
 	projectDir = filepath.Clean(projectDir)
-	allowedDir := filepath.Clean(filepath.Join(homeDir, ".claude", "projects"))
+	allowedDir := filepath.Clean(ProjectsDir())
 	if !strings.HasPrefix(projectDir, allowedDir+string(filepath.Separator)) && projectDir != allowedDir {
 		return fmt.Errorf("invalid project path: %s", target.EncodedPath)
 	}
@@ -39,7 +34,7 @@ func DeleteSession(target DeleteTarget) error {
 
 	// Delete matching marker files (including stale markers) when present.
 	if target.HasActiveMarker {
-		markers := getActiveSessionMarkers(homeDir)
+		markers := getActiveSessionMarkers()
 		if marker, ok := markers[target.SessionID]; ok && marker.MarkerPath != "" {
 			if err := os.Remove(marker.MarkerPath); err != nil && !os.IsNotExist(err) {
 				return fmt.Errorf("remove %s: %w", marker.MarkerPath, err)

--- a/internal/claudefs/paths.go
+++ b/internal/claudefs/paths.go
@@ -1,0 +1,83 @@
+package claudefs
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+var (
+	globalClaudeDir string
+	claudeDirOnce   sync.Once
+	resolvedDir     string
+)
+
+// SetClaudeDir sets the global Claude data directory.
+// Must be called before any path accessor is used (typically from main.go).
+func SetClaudeDir(dir string) {
+	globalClaudeDir = dir
+}
+
+// ClaudeDir returns the resolved Claude data directory.
+// Priority: SetClaudeDir() value > CC9S_CLAUDE_DIR env > ~/.claude
+func ClaudeDir() string {
+	claudeDirOnce.Do(func() {
+		if globalClaudeDir != "" {
+			resolvedDir = globalClaudeDir
+			return
+		}
+		if env := os.Getenv("CC9S_CLAUDE_DIR"); env != "" {
+			resolvedDir = env
+			return
+		}
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			resolvedDir = filepath.Join(".", ".claude")
+			return
+		}
+		resolvedDir = filepath.Join(homeDir, ".claude")
+	})
+	return resolvedDir
+}
+
+// ProjectsDir returns the projects directory path.
+func ProjectsDir() string {
+	return filepath.Join(ClaudeDir(), "projects")
+}
+
+// SessionsDir returns the active session markers directory path.
+func SessionsDir() string {
+	return filepath.Join(ClaudeDir(), "sessions")
+}
+
+// SkillsDir returns the user-level skills directory path.
+func SkillsDir() string {
+	return filepath.Join(ClaudeDir(), "skills")
+}
+
+// CommandsDir returns the user-level commands directory path.
+func CommandsDir() string {
+	return filepath.Join(ClaudeDir(), "commands")
+}
+
+// AgentsDir returns the user-level agents directory path.
+func AgentsDir() string {
+	return filepath.Join(ClaudeDir(), "agents")
+}
+
+// PluginsDir returns the plugins directory path.
+func PluginsDir() string {
+	return filepath.Join(ClaudeDir(), "plugins")
+}
+
+// PluginsInstalledPath returns the installed plugins JSON file path.
+func PluginsInstalledPath() string {
+	return filepath.Join(PluginsDir(), "installed_plugins.json")
+}
+
+// ResetClaudeDir resets the resolved directory cache (for testing only).
+func ResetClaudeDir() {
+	claudeDirOnce = sync.Once{}
+	resolvedDir = ""
+	globalClaudeDir = ""
+}

--- a/internal/claudefs/paths_test.go
+++ b/internal/claudefs/paths_test.go
@@ -1,0 +1,89 @@
+package claudefs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClaudeDir_Default(t *testing.T) {
+	ResetClaudeDir()
+	t.Cleanup(ResetClaudeDir)
+
+	// Ensure no env override
+	t.Setenv("CC9S_CLAUDE_DIR", "")
+
+	dir := ClaudeDir()
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(homeDir, ".claude")
+	if dir != want {
+		t.Errorf("ClaudeDir() = %q, want %q", dir, want)
+	}
+}
+
+func TestClaudeDir_SetClaudeDir(t *testing.T) {
+	ResetClaudeDir()
+	t.Cleanup(ResetClaudeDir)
+
+	SetClaudeDir("/tmp/custom-claude")
+	dir := ClaudeDir()
+	if dir != "/tmp/custom-claude" {
+		t.Errorf("ClaudeDir() = %q, want %q", dir, "/tmp/custom-claude")
+	}
+}
+
+func TestClaudeDir_EnvVar(t *testing.T) {
+	ResetClaudeDir()
+	t.Cleanup(ResetClaudeDir)
+
+	t.Setenv("CC9S_CLAUDE_DIR", "/tmp/env-claude")
+	dir := ClaudeDir()
+	if dir != "/tmp/env-claude" {
+		t.Errorf("ClaudeDir() = %q, want %q", dir, "/tmp/env-claude")
+	}
+}
+
+func TestClaudeDir_SetOverridesEnv(t *testing.T) {
+	ResetClaudeDir()
+	t.Cleanup(ResetClaudeDir)
+
+	t.Setenv("CC9S_CLAUDE_DIR", "/tmp/env-claude")
+	SetClaudeDir("/tmp/flag-claude")
+	dir := ClaudeDir()
+	if dir != "/tmp/flag-claude" {
+		t.Errorf("ClaudeDir() = %q, want %q (flag should override env)", dir, "/tmp/flag-claude")
+	}
+}
+
+func TestSubDirs(t *testing.T) {
+	ResetClaudeDir()
+	t.Cleanup(ResetClaudeDir)
+
+	SetClaudeDir("/tmp/test-claude")
+
+	tests := []struct {
+		name string
+		fn   func() string
+		want string
+	}{
+		{"ProjectsDir", ProjectsDir, "/tmp/test-claude/projects"},
+		{"SessionsDir", SessionsDir, "/tmp/test-claude/sessions"},
+		{"SkillsDir", SkillsDir, "/tmp/test-claude/skills"},
+		{"CommandsDir", CommandsDir, "/tmp/test-claude/commands"},
+		{"AgentsDir", AgentsDir, "/tmp/test-claude/agents"},
+		{"PluginsDir", PluginsDir, "/tmp/test-claude/plugins"},
+		{"PluginsInstalledPath", PluginsInstalledPath, "/tmp/test-claude/plugins/installed_plugins.json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn()
+			if got != tt.want {
+				t.Errorf("%s() = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/claudefs/scanner.go
+++ b/internal/claudefs/scanner.go
@@ -3,7 +3,6 @@ package claudefs
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -18,16 +17,8 @@ func ScanProjects() ScanResult {
 		Projects: make([]Project, 0),
 	}
 
-	// Get ~/.claude path
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		result.Err = err
-		return result
-	}
-
-	claudeDir := filepath.Join(homeDir, ".claude")
-	projectsDir := filepath.Join(claudeDir, "projects")
-	activeMarkers := getActiveSessionMarkers(homeDir)
+	projectsDir := ProjectsDir()
+	activeMarkers := getActiveSessionMarkers()
 
 	// Scan project directories
 	projects, totalSessions, activeCount, err := scanProjectsDir(projectsDir, activeMarkers, start)
@@ -224,13 +215,8 @@ func countMarkdownResources(root string) (count int, exists bool) {
 
 // LoadProjectSessions loads all sessions under a project.
 func LoadProjectSessions(projectEncodedPath string) ([]Session, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("get user home dir: %w", err)
-	}
-
 	// Project directory path
-	projectDir := filepath.Join(homeDir, ".claude", "projects", projectEncodedPath)
+	projectDir := filepath.Join(ProjectsDir(), projectEncodedPath)
 
 	// Scan JSONL files
 	entries, err := os.ReadDir(projectDir)
@@ -239,7 +225,7 @@ func LoadProjectSessions(projectEncodedPath string) ([]Session, error) {
 	}
 
 	// Build active session set
-	activeMarkers := getActiveSessionMarkers(homeDir)
+	activeMarkers := getActiveSessionMarkers()
 
 	// Project-level path resolution (no longer reading JSONL per session)
 	projectPath := DecodePathFS(projectEncodedPath)
@@ -308,9 +294,9 @@ type activeSessionInfo struct {
 }
 
 // getActiveSessionMarkers reads all active session marker files keyed by session ID.
-func getActiveSessionMarkers(homeDir string) map[string]activeSessionInfo {
+func getActiveSessionMarkers() map[string]activeSessionInfo {
 	activeMarkers := make(map[string]activeSessionInfo)
-	sessionsDir := filepath.Join(homeDir, ".claude", "sessions")
+	sessionsDir := SessionsDir()
 
 	entries, err := os.ReadDir(sessionsDir)
 	if err != nil {

--- a/internal/claudefs/session_parser.go
+++ b/internal/claudefs/session_parser.go
@@ -17,13 +17,8 @@ type sessionInspection struct {
 
 // ParseSessionStats parses session statistics (single-pass JSONL traversal).
 func ParseSessionStats(session Session) (*SessionStats, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("get user home dir: %w", err)
-	}
-
 	// Find the JSONL file
-	jsonlPath, err := findSessionJSONL(homeDir, session.ID)
+	jsonlPath, err := findSessionJSONL(session.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -180,8 +175,8 @@ func ParseSessionStats(session Session) (*SessionStats, error) {
 }
 
 // findSessionJSONL locates the JSONL file for a session.
-func findSessionJSONL(homeDir, sessionID string) (string, error) {
-	projectsDir := filepath.Join(homeDir, ".claude", "projects")
+func findSessionJSONL(sessionID string) (string, error) {
+	projectsDir := ProjectsDir()
 	entries, err := os.ReadDir(projectsDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to read projects directory: %w", err)
@@ -207,12 +202,7 @@ func findSessionJSONL(homeDir, sessionID string) (string, error) {
 // limit: number of turns to return
 // Returns: log entries, total turn count, error
 func ParseSessionLog(sessionID string, offset, limit int) ([]LogEntry, int, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, 0, err
-	}
-
-	jsonlPath, err := findSessionJSONL(homeDir, sessionID)
+	jsonlPath, err := findSessionJSONL(sessionID)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/claudefs/skill_scanner.go
+++ b/internal/claudefs/skill_scanner.go
@@ -42,19 +42,14 @@ func ScanSkills() SkillScanResult {
 }
 
 func getSkillDiscoveryRoots() ([]SkillDiscoveryRoot, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-
 	roots := make([]SkillDiscoveryRoot, 0, 4)
 	roots = append(roots, SkillDiscoveryRoot{
-		Path:   filepath.Join(homeDir, ".claude", "skills"),
+		Path:   SkillsDir(),
 		Source: SkillSourceUser,
 		Kind:   SkillKindSkill,
 	})
 	roots = append(roots, SkillDiscoveryRoot{
-		Path:   filepath.Join(homeDir, ".claude", "commands"),
+		Path:   CommandsDir(),
 		Source: SkillSourceUser,
 		Kind:   SkillKindCommand,
 	})
@@ -84,7 +79,7 @@ func getSkillDiscoveryRoots() ([]SkillDiscoveryRoot, error) {
 		})
 	}
 
-	pluginRoots, err := getInstalledPluginDiscoveryRoots(homeDir)
+	pluginRoots, err := getInstalledPluginDiscoveryRoots()
 	if err != nil {
 		return nil, err
 	}
@@ -161,8 +156,8 @@ type installedPluginEntry struct {
 	ProjectPath string `json:"projectPath"`
 }
 
-func getInstalledPluginDiscoveryRoots(homeDir string) ([]SkillDiscoveryRoot, error) {
-	installedPath := filepath.Join(homeDir, ".claude", "plugins", "installed_plugins.json")
+func getInstalledPluginDiscoveryRoots() ([]SkillDiscoveryRoot, error) {
+	installedPath := PluginsInstalledPath()
 	data, err := os.ReadFile(installedPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/cli/action/action.go
+++ b/internal/cli/action/action.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -13,13 +12,12 @@ import (
 var (
 	scanProjects         = claudefs.ScanProjects
 	loadProjectSessions  = claudefs.LoadProjectSessions
-	computeHealthMetrics = claudefs.ComputeHealthMetrics
+	computeHealthMetrics = func() (claudefs.HealthMetrics, error) { return claudefs.ComputeHealthMetrics() }
 	scanSkills           = claudefs.ScanSkills
 	scanAgents           = claudefs.ScanAgents
 	parseSessionStats    = claudefs.ParseSessionStats
 	quickAssessSession   = claudefs.QuickAssessSession
 	nowFunc              = time.Now
-	userHomeDir          = os.UserHomeDir
 	formatTimeRFC3339    = func(t time.Time) string {
 		if t.IsZero() {
 			return ""

--- a/internal/cli/action/action_test.go
+++ b/internal/cli/action/action_test.go
@@ -152,14 +152,12 @@ func TestThemesCurrentNameMatchesStyles(t *testing.T) {
 }
 
 func TestStatusSortsTopProjectsBySessionsThenActiveThenName(t *testing.T) {
-	oldHomeDir := userHomeDir
 	oldScanProjects := scanProjects
 	oldLoadProjectSessions := loadProjectSessions
 	oldComputeHealth := computeHealthMetrics
 	oldScanSkills := scanSkills
 	oldScanAgents := scanAgents
 	t.Cleanup(func() {
-		userHomeDir = oldHomeDir
 		scanProjects = oldScanProjects
 		loadProjectSessions = oldLoadProjectSessions
 		computeHealthMetrics = oldComputeHealth
@@ -167,7 +165,6 @@ func TestStatusSortsTopProjectsBySessionsThenActiveThenName(t *testing.T) {
 		scanAgents = oldScanAgents
 	})
 
-	userHomeDir = func() (string, error) { return "/tmp", nil }
 	scanProjects = func() claudefs.ScanResult {
 		return claudefs.ScanResult{
 			Projects: []claudefs.Project{
@@ -178,7 +175,7 @@ func TestStatusSortsTopProjectsBySessionsThenActiveThenName(t *testing.T) {
 		}
 	}
 	loadProjectSessions = func(string) ([]claudefs.Session, error) { return nil, nil }
-	computeHealthMetrics = func(string) (claudefs.HealthMetrics, error) {
+	computeHealthMetrics = func() (claudefs.HealthMetrics, error) {
 		return claudefs.HealthMetrics{}, errors.New("skip health")
 	}
 	scanSkills = func() claudefs.SkillScanResult { return claudefs.SkillScanResult{} }

--- a/internal/cli/action/status.go
+++ b/internal/cli/action/status.go
@@ -10,17 +10,12 @@ import (
 
 // Status computes the aggregate environment overview.
 func Status() (contract.StatusResult, error) {
-	homeDir, err := userHomeDir()
-	if err != nil {
-		return contract.StatusResult{}, statusError("failed to get home directory")
-	}
-
 	scanResult := scanProjects()
 	if scanResult.Err != nil {
 		return contract.StatusResult{}, statusError("scan projects: %v", scanResult.Err)
 	}
 
-	health, err := computeHealthMetrics(homeDir)
+	health, err := computeHealthMetrics()
 	if err != nil {
 		health = claudefs.HealthMetrics{}
 	}

--- a/internal/cli/command/command.go
+++ b/internal/cli/command/command.go
@@ -509,7 +509,12 @@ func rootHelpLong() string {
 	return `Launch the interactive TUI when no command is provided.
 
 Add --json for machine-readable output.
-Use ` + "`cc9s <resource> --help`" + ` for resource-specific flags and enums.`
+Use ` + "`cc9s <resource> --help`" + ` for resource-specific flags and enums.
+
+Global flags (parsed before subcommands):
+  --theme <name>        Set color theme (or CC9S_THEME env)
+  --claude-dir <path>   Set Claude data directory (or CC9S_CLAUDE_DIR env)
+                        Default: ~/.claude`
 }
 
 func rootHelpExamples() string {

--- a/internal/cli/render/text.go
+++ b/internal/cli/render/text.go
@@ -251,6 +251,7 @@ func renderThemesText(r contract.ThemesResult) string {
 	fmt.Fprintln(&buf)
 	fmt.Fprintf(&buf, "Current: %s\n", r.Current)
 	fmt.Fprintln(&buf, "Usage: cc9s --theme <name>  or  CC9S_THEME=<name> cc9s")
+	fmt.Fprintln(&buf, "       cc9s --claude-dir <path>  or  CC9S_CLAUDE_DIR=<path> cc9s")
 	return buf.String()
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -58,8 +57,6 @@ type AppModel struct {
 	showHelp bool
 	helpScroll int
 	quitting bool
-	homeDir  string
-
 	currentResource      ResourceType
 	globalProjectContext Context // shared project context across Sessions/Skills/Agents
 	inputMode            InputMode
@@ -110,8 +107,6 @@ type AppModel struct {
 
 // NewAppModel creates a new application Model
 func NewAppModel() *AppModel {
-	homeDir, _ := os.UserHomeDir()
-
 	si := textinput.New()
 	si.Prompt = "/"
 	si.Placeholder = "search..."
@@ -128,7 +123,6 @@ func NewAppModel() *AppModel {
 
 	return &AppModel{
 		currentResource:  ResourceProjects,
-		homeDir:          homeDir,
 		projectList:      NewProjectListModel(),
 		resourceRegistry: newResourceRegistry(),
 		searchInput:      si,
@@ -152,9 +146,9 @@ func clockTicker() tea.Cmd {
 	})
 }
 
-func computeHealthCmd(homeDir string) tea.Cmd {
+func computeHealthCmd() tea.Cmd {
 	return func() tea.Msg {
-		health, err := claudefs.ComputeHealthMetrics(homeDir)
+		health, err := claudefs.ComputeHealthMetrics()
 		if err != nil {
 			return StopLoadingMsg{}
 		}
@@ -1305,7 +1299,7 @@ func (a *AppModel) executeCommand(cmdStr string) tea.Cmd {
 			if a.projectList.showHealthColumn && len(a.projectList.projectHealth) == 0 {
 				return tea.Batch(
 					func() tea.Msg { return StartLoadingMsg{Text: "Computing health metrics..."} },
-					computeHealthCmd(a.homeDir),
+					computeHealthCmd(),
 				)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -5,44 +5,54 @@ import (
 	"os"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/kincoy/cc9s/internal/claudefs"
 	cliroot "github.com/kincoy/cc9s/internal/cli/root"
 	"github.com/kincoy/cc9s/internal/ui"
 	"github.com/kincoy/cc9s/internal/ui/styles"
 )
 
-// extractThemeFlag extracts --theme <name> from args.
-// Priority: --theme flag > CC9S_THEME env > "default".
-// Returns the theme name and remaining args with --theme removed.
-func extractThemeFlag(args []string) (string, []string) {
-	var rest []string
-	themeName := ""
-
+// extractGlobalFlags extracts global flags (--theme, --claude-dir) from args.
+// Returns the extracted values and remaining args with flags removed.
+func extractGlobalFlags(args []string) (theme, claudeDir string, rest []string) {
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--theme" {
+		switch args[i] {
+		case "--theme":
 			if i+1 < len(args) {
-				themeName = args[i+1]
+				theme = args[i+1]
 				i++ // skip value
 			}
-			// --theme without value: skip flag, use fallback
+			continue
+		case "--claude-dir":
+			if i+1 < len(args) {
+				claudeDir = args[i+1]
+				i++ // skip value
+			}
 			continue
 		}
 		rest = append(rest, args[i])
 	}
 
-	if themeName != "" {
-		return themeName, rest
+	// Theme fallback: CC9S_THEME env > "default"
+	if theme == "" {
+		if env := os.Getenv("CC9S_THEME"); env != "" {
+			theme = env
+		} else {
+			theme = "default"
+		}
 	}
 
-	if env := os.Getenv("CC9S_THEME"); env != "" {
-		return env, rest
-	}
+	// Claude dir fallback: CC9S_CLAUDE_DIR env is handled inside claudefs.ClaudeDir()
+	// so we only pass the flag value if explicitly set.
 
-	return "default", rest
+	return theme, claudeDir, rest
 }
 
 func main() {
-	themeName, args := extractThemeFlag(os.Args[1:])
+	themeName, claudeDir, args := extractGlobalFlags(os.Args[1:])
 	styles.SetTheme(themeName)
+	if claudeDir != "" {
+		claudefs.SetClaudeDir(claudeDir)
+	}
 
 	if len(args) > 0 {
 		os.Exit(cliroot.Execute(args))

--- a/main_test.go
+++ b/main_test.go
@@ -4,56 +4,87 @@ import (
 	"testing"
 )
 
-func TestExtractThemeFlag(t *testing.T) {
+func TestExtractGlobalFlags(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      []string
-		wantTheme string
-		wantRest  []string
+		name         string
+		args         []string
+		wantTheme    string
+		wantClaudeDir string
+		wantRest     []string
 	}{
 		{
-			name:      "no args",
-			args:      []string{},
-			wantTheme: "default",
-			wantRest:  nil,
+			name:         "no args",
+			args:         []string{},
+			wantTheme:    "default",
+			wantClaudeDir: "",
+			wantRest:     nil,
 		},
 		{
-			name:      "theme flag only",
-			args:      []string{"--theme", "nord"},
-			wantTheme: "nord",
-			wantRest:  nil,
+			name:         "theme flag only",
+			args:         []string{"--theme", "nord"},
+			wantTheme:    "nord",
+			wantClaudeDir: "",
+			wantRest:     nil,
 		},
 		{
-			name:      "theme with CLI args",
-			args:      []string{"--theme", "solarized", "status"},
-			wantTheme: "solarized",
-			wantRest:  []string{"status"},
+			name:         "theme with CLI args",
+			args:         []string{"--theme", "solarized", "status"},
+			wantTheme:    "solarized",
+			wantClaudeDir: "",
+			wantRest:     []string{"status"},
 		},
 		{
-			name:      "CLI args without theme",
-			args:      []string{"sessions", "list", "--json"},
-			wantTheme: "default",
-			wantRest:  []string{"sessions", "list", "--json"},
+			name:         "CLI args without theme",
+			args:         []string{"sessions", "list", "--json"},
+			wantTheme:    "default",
+			wantClaudeDir: "",
+			wantRest:     []string{"sessions", "list", "--json"},
 		},
 		{
-			name:      "theme at end",
-			args:      []string{"status", "--theme", "dracula"},
-			wantTheme: "dracula",
-			wantRest:  []string{"status"},
+			name:         "theme at end",
+			args:         []string{"status", "--theme", "dracula"},
+			wantTheme:    "dracula",
+			wantClaudeDir: "",
+			wantRest:     []string{"status"},
 		},
 		{
-			name:      "theme missing value",
-			args:      []string{"status", "--theme"},
-			wantTheme: "default",
-			wantRest:  []string{"status"},
+			name:         "theme missing value",
+			args:         []string{"status", "--theme"},
+			wantTheme:    "default",
+			wantClaudeDir: "",
+			wantRest:     []string{"status"},
+		},
+		{
+			name:         "claude-dir flag",
+			args:         []string{"--claude-dir", "/tmp/test", "status"},
+			wantTheme:    "default",
+			wantClaudeDir: "/tmp/test",
+			wantRest:     []string{"status"},
+		},
+		{
+			name:         "both flags",
+			args:         []string{"--theme", "nord", "--claude-dir", "/tmp/test", "status"},
+			wantTheme:    "nord",
+			wantClaudeDir: "/tmp/test",
+			wantRest:     []string{"status"},
+		},
+		{
+			name:         "claude-dir missing value",
+			args:         []string{"status", "--claude-dir"},
+			wantTheme:    "default",
+			wantClaudeDir: "",
+			wantRest:     []string{"status"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTheme, gotRest := extractThemeFlag(tt.args)
+			gotTheme, gotClaudeDir, gotRest := extractGlobalFlags(tt.args)
 			if gotTheme != tt.wantTheme {
 				t.Errorf("theme = %q, want %q", gotTheme, tt.wantTheme)
+			}
+			if gotClaudeDir != tt.wantClaudeDir {
+				t.Errorf("claudeDir = %q, want %q", gotClaudeDir, tt.wantClaudeDir)
 			}
 			if len(gotRest) != len(tt.wantRest) {
 				t.Errorf("rest = %v (len %d), want %v (len %d)", gotRest, len(gotRest), tt.wantRest, len(tt.wantRest))
@@ -68,9 +99,9 @@ func TestExtractThemeFlag(t *testing.T) {
 	}
 }
 
-func TestExtractThemeFlag_EnvVar(t *testing.T) {
+func TestExtractGlobalFlags_EnvVar(t *testing.T) {
 	t.Setenv("CC9S_THEME", "nord")
-	gotTheme, gotRest := extractThemeFlag([]string{"status"})
+	gotTheme, _, gotRest := extractGlobalFlags([]string{"status"})
 	if gotTheme != "nord" {
 		t.Errorf("theme = %q, want %q", gotTheme, "nord")
 	}
@@ -79,9 +110,9 @@ func TestExtractThemeFlag_EnvVar(t *testing.T) {
 	}
 }
 
-func TestExtractThemeFlag_FlagOverridesEnv(t *testing.T) {
+func TestExtractGlobalFlags_FlagOverridesEnv(t *testing.T) {
 	t.Setenv("CC9S_THEME", "nord")
-	gotTheme, gotRest := extractThemeFlag([]string{"--theme", "dracula", "status"})
+	gotTheme, _, gotRest := extractGlobalFlags([]string{"--theme", "dracula", "status"})
 	if gotTheme != "dracula" {
 		t.Errorf("theme = %q, want %q (flag should override env)", gotTheme, "dracula")
 	}


### PR DESCRIPTION
### English                                                                                                                          

  Extract all hardcoded `~/.claude` path references scattered across the codebase into a single centralized `paths.go` module, and add
  a new `--claude-dir` global flag (with `CC9S_CLAUDE_DIR` env var fallback) to support custom Claude data directories.

  **What changed:**

  - **New file `internal/claudefs/paths.go`**: Provides `ClaudeDir()`, `ProjectsDir()`, `SessionsDir()`, `SkillsDir()`,                
  `CommandsDir()`, `AgentsDir()`, `PluginsDir()`, `PluginsInstalledPath()` — all path accessors resolve through a single cached entry
  point with priority: `--claude-dir` flag > `CC9S_CLAUDE_DIR` env > `~/.claude`                                                       
  - **New file `internal/claudefs/paths_test.go`**: Full unit test coverage for path resolution and sub-directory accessors
  - **Refactored 6 `claudefs` files** (`scanner.go`, `session_parser.go`, `delete.go`, `analytics.go`, `agent_scanner.go`,
  `skill_scanner.go`): Removed all duplicate `os.UserHomeDir()` calls and manual `filepath.Join(homeDir, ".claude", ...)` patterns,
  replaced with centralized path functions
  - **Refactored `internal/ui/app.go`**: Removed `homeDir` field from `AppModel`, updated `computeHealthCmd()` to use parameterless
  `ComputeHealthMetrics()`
  - **Refactored `main.go`**: `extractThemeFlag()` → `extractGlobalFlags()` now also extracts `--claude-dir`; calls
  `claudefs.SetClaudeDir()` when the flag is provided
  - **Updated `main_test.go`**: Extended tests to cover `--claude-dir` flag parsing
  - **Migrated to new CLI architecture** (cobra/fang from PR #28):
    - `action/status.go`: Removed `homeDir` dependency
    - `action/action.go`: Updated `computeHealthMetrics` signature, removed unused `userHomeDir`
    - `action/action_test.go`: Updated mocks to match new signatures
    - `command/command.go`: Added `--theme` and `--claude-dir` documentation to root help
    - `render/text.go`: Added `--claude-dir` usage hint in themes output

  ### 中文

  将代码库中散落各处的 `~/.claude` 硬编码路径统一收敛到 `paths.go` 模块，并新增 `--claude-dir` 全局 flag（支持 `CC9S_CLAUDE_DIR` 
  环境变量回退），允许用户自定义 Claude 数据目录。                                                                                     
                                       
  **改动要点：**                                                                                                                       

  - **新增 `internal/claudefs/paths.go`**：提供 `ClaudeDir()`、`ProjectsDir()`、`SessionsDir()`
  等路径访问函数，统一通过单一缓存入口解析，优先级为：`--claude-dir` flag > `CC9S_CLAUDE_DIR` 环境变量 > `~/.claude`
  - **新增 `internal/claudefs/paths_test.go`**：完整的单元测试覆盖
  - **重构 6 个 `claudefs` 文件**：移除所有重复的 `os.UserHomeDir()` 调用和手工拼接路径的模式，替换为集中式路径函数
  - **重构 `internal/ui/app.go`**：移除 `AppModel` 中的 `homeDir` 字段
  - **重构 `main.go`**：`extractThemeFlag()` → `extractGlobalFlags()`，新增 `--claude-dir` 解析
  - **更新 `main_test.go`**：扩展测试覆盖 `--claude-dir` flag
  - **适配新 CLI 架构**（cobra/fang，来自 PR #28）：更新
  `action/status.go`、`action/action.go`、`action_test.go`、`command/command.go`、`render/text.go` 中的签名和文档

  ## Test plan

  - [x] `go build ./...` — 编译通过
  - [x] `go test ./...` — 全部 10 个包测试通过
  - [x] 新增 `paths_test.go` 覆盖默认路径 / SetClaudeDir / 环境变量 / flag 覆盖环境变量 / 子目录路径
  - [x] `main_test.go` 覆盖 `--claude-dir` flag 解析和双 flag 组合